### PR TITLE
Problem: key import,export not working correctly (fix #26)

### DIFF
--- a/cmd/cronosd/cmd/root.go
+++ b/cmd/cronosd/cmd/root.go
@@ -95,7 +95,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 	initRootCmd(rootCmd, encodingConfig)
 	overwriteFlagDefaults(rootCmd, map[string]string{
 		flags.FlagChainID:        ChainID,
-		flags.FlagKeyringBackend: "test",
+		flags.FlagKeyringBackend: "os",
 	})
 
 	return rootCmd, encodingConfig


### PR DESCRIPTION
Solution: make default keyring-backend as os 
for consistency

without this pr, adding default is `test`, and others are `os`,
so user cannot find the key correctly without specifying `keyring-backend` 

after applying this pr, when keyring-backend is not specified, default will be `os` , consistent
```
cronosd keys add mykey1 --algo "eth_secp256k1" --index 0 
cronosd keys list 
cronosd keys  show mykey1  
cronosd keys export mykey1   --unarmored-hex --unsafe
cronosd keys unsafe-import-eth-key my5   ....................  --home ./test
cronosd keys  list --home ./test
cronosd keys  show my5 --home ./test
```