### PR TITLE
Problem: Ledger is not enabled and does not work with Crypto.org Chain Ledger app

### DIFF
--- a/app/prefix.go
+++ b/app/prefix.go
@@ -3,14 +3,13 @@ package app
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	cmdcfg "github.com/crypto-org-chain/cronos/cmd/cronosd/config"
-	ethcfg "github.com/tharsis/ethermint/cmd/config"
 )
 
 func SetConfig() {
 	config := sdk.GetConfig()
 	// use the configurations from ethermint
 	cmdcfg.SetBech32Prefixes(config)
-	ethcfg.SetBip44CoinType(config)
+	cmdcfg.SetBip44CoinType(config)
 	// Make sure address is compatible with ethereum
 	config.SetAddressVerifier(VerifyAddressFormat)
 	config.Seal()

--- a/cmd/cronosd/config/config.go
+++ b/cmd/cronosd/config/config.go
@@ -1,10 +1,18 @@
 package config
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 // SetBech32Prefixes sets the global prefixes to be used when serializing addresses and public keys to Bech32 strings.
 func SetBech32Prefixes(config *sdk.Config) {
 	config.SetBech32PrefixForAccount(Bech32PrefixAccAddr, Bech32PrefixAccPub)
 	config.SetBech32PrefixForValidator(Bech32PrefixValAddr, Bech32PrefixValPub)
 	config.SetBech32PrefixForConsensusNode(Bech32PrefixConsAddr, Bech32PrefixConsPub)
+}
+
+func SetBip44CoinType(config *sdk.Config) {
+	config.SetCoinType(BIP44CoinType)
+	config.SetPurpose(sdk.Purpose)
+	config.SetFullFundraiserPath(BIP44HDPath) // nolint: staticcheck
 }

--- a/cmd/cronosd/config/hdpath.go
+++ b/cmd/cronosd/config/hdpath.go
@@ -1,0 +1,11 @@
+// +build !ledger
+
+package config
+
+import ethermint "github.com/tharsis/ethermint/types"
+
+var (
+    BIP44CoinType uint32 = ethermint.Bip44CoinType
+
+    BIP44HDPath = ethermint.BIP44HDPath
+)

--- a/cmd/cronosd/config/hdpath_ledger.go
+++ b/cmd/cronosd/config/hdpath_ledger.go
@@ -1,0 +1,13 @@
+// +build ledger
+
+package config
+
+import (
+    ethaccounts "github.com/ethereum/go-ethereum/accounts"
+)
+
+var (
+    BIP44CoinType uint32 = 394
+
+    BIP44HDPath = ethaccounts.DerivationPath{0x80000000 + 44, 0x80000000 + 394, 0x80000000 + 0, 0, 0}.String()
+)


### PR DESCRIPTION
Solution: (Fix #147) (Fix #148) Add build flag with Crypto.org Chain BIP44 coin type

-----

The use of Coin Type `394` when build with Ledger support is a temp solution so that we have at least the Crypto.org Chain Ledger app to be able to work with `cronosd`.