### PR TITLE
Problem: gravity module is not up to date and pointed to a forked version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 - [cronos#210](https://github.com/crypto-org-chain/cronos/pull/210) re-enabling gravity bridge conditionally
+- [cronos#239](https://github.com/crypto-org-chain/cronos/pull/239) switch gravity module to upstream version and bump to v0.2.23
 
 
 *November 30, 2021*

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/peggyjv/gravity-bridge/module v0.2.0
+	github.com/peggyjv/gravity-bridge/module v0.2.23
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.4.1
 	github.com/spf13/cobra v1.2.1
@@ -166,7 +166,3 @@ replace github.com/ethereum/go-ethereum => github.com/crypto-org-chain/go-ethere
 replace github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.44.2
 
 replace github.com/tharsis/ethermint => github.com/crypto-org-chain/ethermint v0.7.2-cronos-4
-
-// FIXME: update after PR merged: https://github.com/PeggyJV/gravity-bridge/pull/182
-// https://github.com/crypto-org-chain/gravity-bridge/tree/cronos
-replace github.com/peggyjv/gravity-bridge/module => github.com/crypto-org-chain/gravity-bridge/module v0.1.22-0.20211011065300-a09cf050d304

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,6 @@ github.com/crypto-org-chain/ethermint v0.7.2-cronos-4 h1:NaCc0L5zN2u7B9WofmhJfur
 github.com/crypto-org-chain/ethermint v0.7.2-cronos-4/go.mod h1:J96LX4KvLyl+5jV6+mt/4l6srtGX/mdDTuqQQuYrdDk=
 github.com/crypto-org-chain/go-ethereum v1.10.3-patched h1:kr6oQIYOi2VC8SZwkhlUDZE1Omit/YHVysKMgCB2nes=
 github.com/crypto-org-chain/go-ethereum v1.10.3-patched/go.mod h1:99onQmSd1GRGOziyGldI41YQb7EESX3Q4H41IfJgIQQ=
-github.com/crypto-org-chain/gravity-bridge/module v0.1.22-0.20211011065300-a09cf050d304 h1:5A6pzj5uQPQCCO96SqsCCoar/DfjOxIdadBHX3ncotU=
-github.com/crypto-org-chain/gravity-bridge/module v0.1.22-0.20211011065300-a09cf050d304/go.mod h1:7sqblrhSS7+I94DDIWz98N2mcXR5hL7f+EaV054sBMQ=
 github.com/crypto-org-chain/ibc-go v1.2.1-hooks h1:wuWaQqm/TFKJQwuFgjCPiPumQio+Yik5Z1DObDExrrU=
 github.com/crypto-org-chain/ibc-go v1.2.1-hooks/go.mod h1:YieSs25Y0TSFR67qg6Elge34yJNEOjYhYB+HNQQLoSQ=
 github.com/crypto-org-chain/keyring v1.1.6-fixes h1:AUFSu56NY6XobY6XfRoDx6v3loiOrHK5MNUm32GEjwA=
@@ -930,6 +928,8 @@ github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0Mw
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+github.com/peggyjv/gravity-bridge/module v0.2.23 h1:suFIjm2AntN2sfzylbAWlcikss7B7kUNijIjScn6o0E=
+github.com/peggyjv/gravity-bridge/module v0.2.23/go.mod h1:7sqblrhSS7+I94DDIWz98N2mcXR5hL7f+EaV054sBMQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -3873,14 +3873,13 @@
     sha256 = "0f146yjqwx2mr110kl8scjhqd08hys7vr5z0d0a3lskb6yy22gfg"
 
 ["github.com/peggyjv/gravity-bridge/module"]
-  sumVersion = "v0.1.22-0.20211011065300-a09cf050d304"
+  sumVersion = "v0.2.23"
   relPath = "module"
-  vendorPath = "github.com/crypto-org-chain/gravity-bridge/module"
   ["github.com/peggyjv/gravity-bridge/module".fetch]
     type = "git"
-    url = "https://github.com/crypto-org-chain/gravity-bridge"
-    rev = "a09cf050d304156a7b6db5f95bcb31bad3681c33"
-    sha256 = "03fdvfpzb7bqzqpgw7chd8rm6dsk6a2vybr5pvmg3h4nm5v9wm3l"
+    url = "https://github.com/peggyjv/gravity-bridge"
+    rev = "eca0feb0d188070564aa8dd7e623437f5415a5ce"
+    sha256 = "0y3hvpy8s0jqxrwij5dx86mb7gcg104vgq19fbqbwzsc6wlax50h"
 
 ["github.com/pelletier/go-toml"]
   sumVersion = "v1.9.4"


### PR DESCRIPTION
Solution: Point to upstream and use latest version v0.2.23 since the bugfix https://github.com/PeggyJV/gravity-bridge/pull/182 has been merged to upstream

