### PR TITLE
Problem: go 1.17 is not used in nix build

### DIFF
--- a/integration_tests/shell.nix
+++ b/integration_tests/shell.nix
@@ -2,7 +2,8 @@
 pkgs.mkShell {
   buildInputs = [
     pkgs.jq
-    pkgs.go
+    pkgs.go_1_17
+    pkgs.gomod2nix
     (import ../. { inherit pkgs; }) # cronosd
     pkgs.start-scripts
     pkgs.go-ethereum

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -12,8 +12,14 @@ in
 import sources.nixpkgs {
   overlays = [
     (_: pkgs: dapptools) # use released version to hit the binary cache
-    (import (sources.gomod2nix + "/overlay.nix"))
-    (import (sources.poetry2nix + "/overlay.nix"))
+    (_: pkgs: rec {
+      buildGoApplication = pkgs.callPackage (import (sources.gomod2nix + "/builder")) {
+        go = pkgs.go_1_17;
+      };
+      gomod2nix = pkgs.callPackage (import (sources.gomod2nix)) {
+        inherit buildGoApplication;
+      };
+    })
     (_: pkgs: {
       pystarport = pkgs.poetry2nix.mkPoetryApplication {
         projectDir = sources.pystarport;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -18,10 +18,10 @@
         "homepage": null,
         "owner": "tweag",
         "repo": "gomod2nix",
-        "rev": "67f22dd738d092c6ba88e420350ada0ed4992ae8",
-        "sha256": "0a9rhw6djgcrky5nzly3srsl8095q42f2nyzxyisp9fh9fg70nih",
+        "rev": "596d01fd55ed8521853807df1f4e9d858cf75d7e",
+        "sha256": "040xh14gh1x9p80adwfzs21h1hq1di1qkw7jpzyhsm13wv5z2ja2",
         "type": "tarball",
-        "url": "https://github.com/tweag/gomod2nix/archive/67f22dd738d092c6ba88e420350ada0ed4992ae8.tar.gz",
+        "url": "https://github.com/tweag/gomod2nix/archive/596d01fd55ed8521853807df1f4e9d858cf75d7e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "gravity-bridge": {
@@ -49,27 +49,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "release-21.05",
+        "branch": "release-21.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4b7e51865e44d3afc564e3a3111af12be1003251",
-        "sha256": "0n3cf1wgw3j8hswxjy5q1vcbyyml6z0c57jc5zjkgrvbkp4g3b2c",
+        "rev": "d2f47b7dcd558a7727606319fd8661a4c3311b4a",
+        "sha256": "1kkykw8i80jcnw6iz7a4kndia3fig53jm1kzqi4xbfgxamfwqnzb",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/4b7e51865e44d3afc564e3a3111af12be1003251.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "poetry2nix": {
-        "branch": "master",
-        "description": "Convert poetry projects to nix automagically [maintainer=@adisbladis] ",
-        "homepage": "",
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "rev": "4bc4abd85cb6031e1e85328cbb028e085f85469a",
-        "sha256": "192c9r10x20pw66cf8n412sxazpdkav74m9yrgzjg0yq57idlkiw",
-        "type": "tarball",
-        "url": "https://github.com/nix-community/poetry2nix/archive/4bc4abd85cb6031e1e85328cbb028e085f85469a.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d2f47b7dcd558a7727606319fd8661a4c3311b4a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pystarport": {


### PR DESCRIPTION
Closes: #250

Solution:
- update nixpkgs to release-21.11
- use go_1_17 as default go
- use builtin poetry2nix

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)

