### PR TITLE
Problem: 0.70-rc1 testnet does not support eth_call for blocks prior to upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [cronos#287](https://github.com/crypto-org-chain/cronos/pull/287) call upgrade handler before sealing app
 - [cronos#323](https://github.com/crypto-org-chain/cronos/pull/323) Upgrade gravity bridge to v0.3.9 which contain a bugfix on `batchTxExecuted.`
 - [cronos#324](https://github.com/crypto-org-chain/cronos/pull/324) Update to cosmos-sdk `v0.45.1`, which fixes an OOM issue.
+- [cronos#329](https://github.com/crypto-org-chain/cronos/pull/329) Fix panic of eth_call on blocks prior to upgrade. 
 
 *December 10, 2021*
 

--- a/go.mod
+++ b/go.mod
@@ -164,7 +164,7 @@ replace (
 	// See https://github.com/tecbot/gorocksdb/pull/216
 	github.com/tecbot/gorocksdb => github.com/cosmos/gorocksdb v1.1.1
 
-	github.com/tharsis/ethermint => github.com/crypto-org-chain/ethermint v0.10.0-alpha1-cronos-3
+	github.com/tharsis/ethermint => github.com/crypto-org-chain/ethermint v0.10.0-alpha1-cronos-4
 
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crypto-org-chain/ethermint v0.10.0-alpha1-cronos-3 h1:O3pyvDcKjlA82J3lMzm07e06Lhi2SH6AHu8609effkM=
-github.com/crypto-org-chain/ethermint v0.10.0-alpha1-cronos-3/go.mod h1:mDIs9UkvLmjjg6cJX0dyO2GKn0GP6cuq4AfbDnFZl/4=
+github.com/crypto-org-chain/ethermint v0.10.0-alpha1-cronos-4 h1:KmP8fnsuZUKSE2f4i9osKq+KYjbqA9aJ8PX/osD47Wo=
+github.com/crypto-org-chain/ethermint v0.10.0-alpha1-cronos-4/go.mod h1:mDIs9UkvLmjjg6cJX0dyO2GKn0GP6cuq4AfbDnFZl/4=
 github.com/crypto-org-chain/ibc-go/v2 v2.0.2-hooks h1:d2MOrJQE6lZQ+nUznUaSlE8/QQZ4j5rkv5hw2DnCt50=
 github.com/crypto-org-chain/ibc-go/v2 v2.0.2-hooks/go.mod h1:XUmW7wmubCRhIEAGtMGS+5IjiSSmcAwihoN/yPGd6Kk=
 github.com/crypto-org-chain/keyring v1.1.6-fixes h1:AUFSu56NY6XobY6XfRoDx6v3loiOrHK5MNUm32GEjwA=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -3668,13 +3668,13 @@
     sha256 = "1sgjf2vaq554ybc0cwkzn17cz2ibzph2rq0dgaw21c2hym09437x"
 
 ["github.com/tharsis/ethermint"]
-  sumVersion = "v0.10.0-alpha1-cronos-3"
+  sumVersion = "v0.10.0-alpha1-cronos-4"
   vendorPath = "github.com/crypto-org-chain/ethermint"
   ["github.com/tharsis/ethermint".fetch]
     type = "git"
     url = "https://github.com/crypto-org-chain/ethermint"
-    rev = "1bd9ad9a6ad11381c50b162e89d60ecea4a06110"
-    sha256 = "14vwv1j53y1whhwz4scrjhnasr7nr9k6axz19wcjgxnwyl516xbi"
+    rev = "caa29c298bd80e9659d427368d598e7f46d04ec3"
+    sha256 = "1gpjsfqld2w6jxcq12g57253zg1fyzw77k3niw1n18y25l80dy0k"
 
 ["github.com/tidwall/gjson"]
   sumVersion = "v1.6.7"


### PR DESCRIPTION
Closes: #327
Solution:
- fix base fee check logic in ethermint.

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)

