### PR TITLE
Problem: miss the exact crc20 token contract deployed

### DIFF
--- a/contracts/src/CronosCRC20.sol
+++ b/contracts/src/CronosCRC20.sol
@@ -1,0 +1,13 @@
+pragma solidity 0.6.11;
+
+import "./ModuleCRC20.sol";
+
+contract CronosCRC20 is ModuleCRC20 {
+    constructor (
+        string memory _name,
+        string memory _denom,
+        uint8 _decimal
+    ) ModuleCRC20(_denom, _decimal) public {
+        setName(_name);
+    }
+}


### PR DESCRIPTION
Solution: add the exact crc20 token contract to match the commit, functionally the same as ModuleCRC20, just the name is set when initiating the instance.