### PR TITLE
Problem: incorrect licensing information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
-  Copyright 2021, CRO Protocol Labs ("Crypto.org").
-  Copyright 2018 - 2020, Foris Limited ("Crypto.com"). 
+  Copyright 2021-present, CRO Protocol Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Solution: fixed the license (cronos code didn't exist before 2021)
