### PR TITLE
Problem: missing ADR draft for a transition to CCV (fixes #194)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -31,4 +31,4 @@ To suggest an ADR, please make use of the [ADR template](./adr-template.md) prov
 | [002](./adr-002.md) | Use a custom fork of ibc-go | Accepted |
 | [003](./adr-003.md) | Add Fee Market Module | Accepted |
 | [004](./adr-004.md) | Tokens conversion in Cronos | Accepted |
-| [005](./adr-005.md) | Cross-chain Validation for Gravity Bridge | Proposed |
+| [005](./adr-005.md) | Cross-chain Validation for Gravity Bridge | Rejected |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -31,3 +31,4 @@ To suggest an ADR, please make use of the [ADR template](./adr-template.md) prov
 | [002](./adr-002.md) | Use a custom fork of ibc-go | Accepted |
 | [003](./adr-003.md) | Add Fee Market Module | Accepted |
 | [004](./adr-004.md) | Tokens conversion in Cronos | Accepted |
+| [005](./adr-005.md) | Cross-chain Validation for Gravity Bridge | Proposed |

--- a/docs/architecture/adr-005.md
+++ b/docs/architecture/adr-005.md
@@ -48,6 +48,7 @@ Proposed
 
 - Complexity and maintenance overhead of a separate network codebase and operation. (Note that the Gravity Bridge infrastructure demands an inherent operational complexity, e.g. the need to run Ethereum full nodes, regardless of where the module is included.)
 - A slight increase in the cross-chain transfer latency. (The overall time will still be dominated by the operations on Ethereum though.)
+- More complex refund or cancellation workflows, as token transfers can get stuck in IBC or Ethereum submissions.
 
 ### Neutral
 

--- a/docs/architecture/adr-005.md
+++ b/docs/architecture/adr-005.md
@@ -1,0 +1,61 @@
+# ADR 005: Cross-chain Validation for Gravity Bridge
+
+## Changelog
+* 2022-05-31: first draft
+
+## Context
+
+Cross-chain Validation is a shared security mechanism over IBC that leads to the creation of "provider" and "consumer" blockchains.
+The provider blockchain communicates staking changes to consumer blockchain(s), while the consumer blockchain may communicate slashing evidence to the provider blockchain. The consumer blockchains are created via governance proposals and their validator set is identical to their provider blockchain.
+This setup is potentially suited for scenarios where the consumer blockchains contain a more experimental code, because any potential issues will not
+directly affect their provider blockchain. For example, if the consumer blockchain panics and halts due to a bug, the provider blockchain does not halt and continues operating.
+
+Gravity Bridge is an experimental module (plus its surrounding infrastructure) that allows bi-directional ERC20 token transfers with Ethereum and is included under an experimental flag in Cronos (see [ADR 001](./adr-001.md)), i.e. it is disabled in the normal operation.
+
+
+## Decision
+
+Gravity Bridge will be separated out to a dedicated network that will have the consumer-provider relationship with Cronos.
+The implementation can be done in the following stages:
+
+1. A new blockchain source tree is created for the Gravity Bridge-related code:
+- This can either be in a dedicated repository or inside the Cronos repository using the Go 1.18 workspace feature (TODO: which one?).
+- The new codebase will only import needed Cosmos SDK modules, ibc-go, and Gravity Bridge.
+- It could potentially also import the packet forwarder middleware: https://github.com/strangelove-ventures/packet-forward-middleware
+- Alternatively, it could implement something similar to the packet forwarder middleware in order to automate incoming token transfers (i.e. so that incoming transfers from Ethereum are automatically sent via IBC to Cronos).
+
+2. The Gravity Bridge-related code is removed from the Cronos module/application.
+
+3. The x/ccv module is added to the Cronos and the Gravity Bridge applications.
+
+4. The public contracts and standards may be revised to remove the `send_to_ethereum` function and related events.
+
+## Status
+
+Proposed
+
+## Consequences
+
+### Positive
+
+- Isolation of Gravity Bridge: any potential issues discovered in it will not affect the overall Cronos network's operation.
+- Independent processing of transactions: any transaction spikes in the EVM or Gravity Bridge modules will not affect each other directly.
+- Storage sharding: the storage needed by Gravity Bridge can live on a different node from the one executing Cronos with the EVM module.
+- Simplified interface for cross-chain token transfers: only IBC-related logic needs to be considered inside EVM.
+- Independent upgrades: any breaking changes in Gravity Bridge will not demand upgrades on Cronos (and vice versa).
+
+### Negative
+
+- Complexity and maintenance overhead of a separate network codebase and operation. (Note that the Gravity Bridge infrastructure demands an inherent operational complexity, e.g. the need to run Ethereum full nodes, regardless of where the module is included.)
+- A slight increase in the cross-chain transfer latency. (The overall time will still be dominated by the operations on Ethereum though.)
+
+### Neutral
+
+- Additional code source tree is needed.
+- Two binaries need to be generated and possibly bundled together.
+
+## References
+
+* https://github.com/cosmos/ibc/tree/marius/ccv/spec/app/ics-028-cross-chain-validation
+* https://github.com/cosmos/interchain-security 
+* https://github.com/PeggyJV/gravity-bridge 

--- a/docs/architecture/adr-005.md
+++ b/docs/architecture/adr-005.md
@@ -2,6 +2,7 @@
 
 ## Changelog
 * 2022-05-31: first draft
+* 2022-06-02: updated status
 
 ## Context
 

--- a/docs/architecture/adr-005.md
+++ b/docs/architecture/adr-005.md
@@ -33,7 +33,7 @@ The implementation can be done in the following stages:
 
 ## Status
 
-Proposed
+Rejected
 
 ## Consequences
 


### PR DESCRIPTION
Solution: sketched out a draft for CCV usage where Cronos is the provider chain
for Gravity Bridge.
(note that the original issue considered Cronos could be a consumer chain
which may still be a valid option, but the complexity of transition may be too high.)
