### PR TITLE
Problem: nix built binary version number is not bumped

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@
 , rev ? "dirty"
 }:
 let
-  version = "v0.7.0";
+  version = "v0.8.0";
   pname = "cronosd";
   tags = lib.concatStringsSep "," (
     [ "ledger" "netgo" network ]


### PR DESCRIPTION
Solution:
- bump to `v0.8.0` to prepare gravity-bridge testnet binaries.

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)

