### PR TITLE
Problem: integration test nix-shell env building is slow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,23 @@ jobs:
           name: debug-files
           path: debug_files.tar.gz
           if-no-files-found: ignore
+
+  upload-cache:
+    if: github.event_name == 'push'
+    needs: ["integration_tests"]
+    strategy:
+      matrix:
+        os: [macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v15
+      - uses: cachix/cachix-action@v10
+        with:
+          name: cronos
+          extraPullNames: dapp
+          # github don't pass secrets for pull request from fork repos,
+          # in that case the push is disabled naturally.
+          signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
+      - name: 'instantiate integration test env'
+        run: nix-instantiate integration_tests/shell.nix


### PR DESCRIPTION
Solution:
- upload x86-macOS binary cache in CI

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)

