### PR TITLE
Problem: existing crc20 are not compatible with crc21 standard

### DIFF
--- a/contracts/src/ModuleCRC20Proxy.sol
+++ b/contracts/src/ModuleCRC20Proxy.sol
@@ -3,39 +3,57 @@ pragma solidity ^0.6.8;
 import "ds-math/math.sol";
 import "./ModuleCRC20.sol";
 
+contract ProxyAuthority {
+    address proxyAddress;
+
+    constructor(address _proxyAddress) public {
+        proxyAddress = _proxyAddress;
+    }
+
+    function canCall(
+        address src, address dst, bytes4 sig
+    ) public view returns (bool) {
+        if (msg.sender == proxyAddress) {
+            return true;
+        }
+
+        return false;
+    }
+}
+
 contract ModuleCRC20Proxy is DSMath {
     // sha256('cronos-evm')[:20]
     address constant module_address = 0x89A7EF2F08B1c018D5Cc88836249b84Dd5392905;
-    uint256 private MAX_UINT = 2**256 - 1;
     ModuleCRC20 crc20Contract;
 
     event __CronosSendToEvmChain(address indexed sender, address indexed recipient, uint256 indexed chain_id, uint256 amount, uint256 bridge_fee, bytes extraData);
     event __CronosCancelSendToEvmChain(address indexed sender, uint256 id);
 
+    /**
+        Can be instantiated only by crc20 contract owner
+    **/
     constructor(address crc20Contract_) public {
         crc20Contract = ModuleCRC20(crc20Contract_);
+        crc20Contract.setAuthority(DSAuthority(address(new ProxyAuthority(address(this)))));
     }
 
 
     /**
         Internal functions to be called by cronos module.
-
-        In the proxy contract, we don't mint but transfer asset to the destination since the proxy account
-        should be initialized with MAX_UINT tokens
     **/
     function mint_by_cronos_module(address addr, uint amount) public {
         require(msg.sender == module_address);
-        crc20Contract.transfer(addr, amount);
+        crc20Contract.mint(addr, amount);
     }
 
     /**
         Evm hooks functions
     **/
 
-    // send to another chain through gravity bridge
+    // send to another chain through gravity bridge, require approval for the burn.
     function send_to_evm_chain(address recipient, uint amount, uint chain_id, uint bridge_fee, bytes calldata extraData) external {
         // transfer back the token to the proxy account
-        crc20Contract.transferFrom(msg.sender, address(this), add(amount,bridge_fee));
+        crc20_burn(msg.sender, amount);
         emit __CronosSendToEvmChain(msg.sender, recipient, chain_id, amount, bridge_fee, extraData);
     }
 
@@ -45,14 +63,12 @@ contract ModuleCRC20Proxy is DSMath {
     }
 
     /**
-     * @dev Returns the number of tokens currently in circulation
-     * This value should reflect the number of token which are locked in the gravity bridge
-     * corresponding to the crc20 token.
-     * Note that it is not an accurate number but only an estimation as they may be latency between the ethereum network
-     * and cronos network.
-	 *
-	 */
-    function totalSupply() public view returns (uint256) {
-        return MAX_UINT - crc20Contract.balanceOf(address(this));
+        Internal functions
+    **/
+
+    // burn the token on behalf of the user. requires approval
+    function crc20_burn(address addr, uint amount) internal {
+        crc20Contract.move(addr, address(this), amount);
+        crc20Contract.burn(amount);
     }
 }

--- a/contracts/src/ModuleCRC20Proxy.sol
+++ b/contracts/src/ModuleCRC20Proxy.sol
@@ -25,6 +25,7 @@ contract ModuleCRC20Proxy is DSMath {
     // sha256('cronos-evm')[:20]
     address constant module_address = 0x89A7EF2F08B1c018D5Cc88836249b84Dd5392905;
     ModuleCRC20 crc20Contract;
+    bool isSource;
 
     event __CronosSendToEvmChain(address indexed sender, address indexed recipient, uint256 indexed chain_id, uint256 amount, uint256 bridge_fee, bytes extraData);
     event __CronosCancelSendToEvmChain(address indexed sender, uint256 id);
@@ -32,9 +33,21 @@ contract ModuleCRC20Proxy is DSMath {
     /**
         Can be instantiated only by crc20 contract owner
     **/
-    constructor(address crc20Contract_) public {
+    constructor(address crc20Contract_, bool isSource_) public {
         crc20Contract = ModuleCRC20(crc20Contract_);
         crc20Contract.setAuthority(DSAuthority(address(new ProxyAuthority(address(this)))));
+        isSource = isSource_;
+    }
+
+    /**
+        views
+    **/
+    function crc20() public view returns (address) {
+        return address(crc20Contract);
+    }
+
+    function is_source() public view returns (bool) {
+        return isSource;
     }
 
 
@@ -46,6 +59,22 @@ contract ModuleCRC20Proxy is DSMath {
         crc20Contract.mint(addr, amount);
     }
 
+    function burn_by_cronos_module(address addr, uint amount) public {
+        require(msg.sender == module_address);
+        crc20_burn(addr, amount);
+    }
+
+    function transfer_by_cronos_module(address addr, uint amount) public {
+        require(msg.sender == module_address);
+        crc20Contract.move(addr, module_address, amount);
+    }
+
+    function transfer_from_cronos_module(address addr, uint amount) public {
+        require(msg.sender == module_address);
+        crc20Contract.move(module_address, addr, amount);
+    }
+
+
     /**
         Evm hooks functions
     **/
@@ -53,7 +82,11 @@ contract ModuleCRC20Proxy is DSMath {
     // send to another chain through gravity bridge, require approval for the burn.
     function send_to_evm_chain(address recipient, uint amount, uint chain_id, uint bridge_fee, bytes calldata extraData) external {
         // transfer back the token to the proxy account
-        crc20_burn(msg.sender, amount);
+        if (isSource) {
+            crc20Contract.move(addr, module_address, amount);
+        } else {
+            crc20_burn(msg.sender, amount);
+        }
         emit __CronosSendToEvmChain(msg.sender, recipient, chain_id, amount, bridge_fee, extraData);
     }
 

--- a/contracts/src/ModuleCRC20Proxy.sol
+++ b/contracts/src/ModuleCRC20Proxy.sol
@@ -1,0 +1,58 @@
+pragma solidity ^0.6.8;
+
+import "ds-math/math.sol";
+import "./ModuleCRC20.sol";
+
+contract ModuleCRC20Proxy is DSMath {
+    // sha256('cronos-evm')[:20]
+    address constant module_address = 0x89A7EF2F08B1c018D5Cc88836249b84Dd5392905;
+    uint256 private MAX_UINT = 2**256 - 1;
+    ModuleCRC20 crc20Contract;
+
+    event __CronosSendToEvmChain(address indexed sender, address indexed recipient, uint256 indexed chain_id, uint256 amount, uint256 bridge_fee, bytes extraData);
+    event __CronosCancelSendToEvmChain(address indexed sender, uint256 id);
+
+    constructor(address crc20Contract_) public {
+        crc20Contract = ModuleCRC20(crc20Contract_);
+    }
+
+
+    /**
+        Internal functions to be called by cronos module.
+
+        In the proxy contract, we don't mint but transfer asset to the destination since the proxy account
+        should be initialized with MAX_UINT tokens
+    **/
+    function mint_by_cronos_module(address addr, uint amount) public {
+        require(msg.sender == module_address);
+        crc20Contract.transfer(addr, amount);
+    }
+
+    /**
+        Evm hooks functions
+    **/
+
+    // send to another chain through gravity bridge
+    function send_to_evm_chain(address recipient, uint amount, uint chain_id, uint bridge_fee, bytes calldata extraData) external {
+        // transfer back the token to the proxy account
+        crc20Contract.transferFrom(msg.sender, address(this), add(amount,bridge_fee));
+        emit __CronosSendToEvmChain(msg.sender, recipient, chain_id, amount, bridge_fee, extraData);
+    }
+
+    // cancel a send to chain transaction considering if it hasnt been batched yet.
+    function cancel_send_to_evm_chain(uint256 id) external {
+        emit __CronosCancelSendToEvmChain(msg.sender, id);
+    }
+
+    /**
+     * @dev Returns the number of tokens currently in circulation
+     * This value should reflect the number of token which are locked in the gravity bridge
+     * corresponding to the crc20 token.
+     * Note that it is not an accurate number but only an estimation as they may be latency between the ethereum network
+     * and cronos network.
+	 *
+	 */
+    function totalSupply() public view returns (uint256) {
+        return MAX_UINT - crc20Contract.balanceOf(address(this));
+    }
+}


### PR DESCRIPTION
**Open this PR just for discussion**


Pro of this methods :

- No need to use a wrapper, which remove the burden to deal with wrap tokens


Cons:

- Need an extra approval for transferring to Ethereum
- The totalSupply should be queried to the proxy contract, not the actual CRC20 contract. Not sure if it can be an issue for existing dapps? 



