### PR TITLE
Problem: recent golang compiler 1.19.6 is not used

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - id: changed-files
         uses: tj-actions/changed-files@v34
         with:
@@ -52,7 +52,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - id: changed-files
         uses: tj-actions/changed-files@v34
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
         with:

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -108,7 +108,7 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'pull_request' 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Display go version
         run: go version
       - run: make build
@@ -129,7 +129,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Display go version
         run: go version
       - name: Install runsim
@@ -155,7 +155,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18.3
+          go-version: 1.19
       - name: Checkout Comment PR Branch
         uses: actions/checkout@v3
         if: github.event_name == 'issue_comment'
@@ -210,7 +210,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18.3
+          go-version: 1.19
       - name: Checkout Comment PR Branch
         uses: actions/checkout@v3
         if: github.event_name == 'issue_comment'
@@ -265,7 +265,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18.3
+          go-version: 1.19
       - name: Checkout Comment PR Branch
         uses: actions/checkout@v3
         if: github.event_name == 'issue_comment'
@@ -320,7 +320,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18.3
+          go-version: 1.19
       - name: Checkout Comment PR Branch
         uses: actions/checkout@v3
         if: github.event_name == 'issue_comment'

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ lint-nix:
 ###############################################################################
 
 PACKAGE_NAME:=github.com/crypto-org-chain/cronos
-GOLANG_CROSS_VERSION  = v1.18
+GOLANG_CROSS_VERSION  = v1.19
 release-dry-run:
 	docker run \
 		--rm \

--- a/flake.lock
+++ b/flake.lock
@@ -56,16 +56,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658285632,
-        "narHash": "sha256-zRS5S/hoeDGUbO+L95wXG9vJNwsSYcl93XiD0HQBXLk=",
+        "lastModified": 1676570994,
+        "narHash": "sha256-6y/vRBWzgXFfmiNLc2gwyWwAt3Rfy0wKmuMej8DCmGU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5342fc6fb59d0595d26883c3cadff16ce58e44f3",
+        "rev": "fd00212f449f62cf5ec51dc782dae36572142140",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "master",
+        "ref": "release-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
     flake-utils.url = "github:numtide/flake-utils";
     nix-bundle-exe = {
       url = "github:3noch/nix-bundle-exe";
@@ -46,7 +46,7 @@
           devShells = {
             cronosd = pkgs.mkShell {
               buildInputs = with pkgs; [
-                go_1_18
+                go_1_19
                 rocksdb
                 gomod2nix
               ];
@@ -56,7 +56,14 @@
         }
       )
     ) // {
-      overlay = final: _: {
+      overlay = final: prev: {
+        go_1_19 = prev.go_1_19.overrideAttrs (_: rec {
+          version = "1.19.6";
+          src = final.fetchurl {
+            url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
+            hash = "sha256-1/ABP4Lm1/hizGy1yM20ju9fLiObNbqpfi8adGYEN2c=";
+          };
+        });
         bundle-exe = import nix-bundle-exe { pkgs = final; };
         # make-tarball don't follow symbolic links to avoid duplicate file, the bundle should have no external references.
         # reset the ownership and permissions to make the extract result more normal.

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
         go_1_19 = prev.go_1_19.overrideAttrs (_: rec {
           version = "1.19.6";
           src = final.fetchurl {
-            url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
+            url = "https://go.dev/dl/go${version}.src.tar.gz";
             hash = "sha256-1/ABP4Lm1/hizGy1yM20ju9fLiObNbqpfi8adGYEN2c=";
           };
         });

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crypto-org-chain/cronos
 
-go 1.18
+go 1.19
 
 require (
 	cosmossdk.io/errors v1.0.0-beta.7

--- a/integration_tests/poetry.lock
+++ b/integration_tests/poetry.lock
@@ -657,11 +657,11 @@ six = ">=1.9.0"
 
 [[package]]
 name = "pathspec"
-version = "0.9.0"
+version = "0.10.3"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "main"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.7"
 
 [[package]]
 name = "pep8-naming"
@@ -1544,8 +1544,8 @@ parsimonious = [
     {file = "parsimonious-0.8.1.tar.gz", hash = "sha256:3add338892d580e0cb3b1a39e4a1b427ff9f687858fdd61097053742391a9f6b"},
 ]
 pathspec = [
-    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
-    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+    {file = "pathspec-0.10.3-py3-none-any.whl", hash = "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6"},
+    {file = "pathspec-0.10.3.tar.gz", hash = "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"},
 ]
 pep8-naming = [
     {file = "pep8-naming-0.11.1.tar.gz", hash = "sha256:a1dd47dd243adfe8a83616e27cf03164960b507530f155db94e10b36a6cd6724"},

--- a/integration_tests/pyproject.toml
+++ b/integration_tests/pyproject.toml
@@ -27,6 +27,7 @@ pysha3 = "^1.0.2"
 jsonnet = "^0.18.0"
 eth-account = { git = "https://github.com/mmsqe/eth-account.git", branch = "v0.5.8-rc0" }
 cprotobuf = "^0.1.11"
+pathspec = "^0.10.1"
 flaky = "^3.7.0"
 
 [tool.poetry.dev-dependencies]

--- a/integration_tests/test_gravity.py
+++ b/integration_tests/test_gravity.py
@@ -260,7 +260,7 @@ def test_gravity_transfer(gravity):
     assert txreceipt.status == 1, "should success"
     assert erc20.caller.balanceOf(ADDRS["validator"]) == balance - amount
 
-    denom = f"gravity{erc20.address}"
+    denom = f"gravity{erc20.address.lower()}"
 
     def check_gravity_native_tokens():
         "check the balance of gravity native token"
@@ -331,7 +331,7 @@ def test_gov_token_mapping(gravity):
         CONTRACTS["TestERC20Utility"],
     )
     print("crc21 contract", crc21.address)
-    denom = f"gravity{erc20.address}"
+    denom = f"gravity{erc20.address.lower()}"
 
     print("check the contract mapping not exists yet")
     with pytest.raises(AssertionError):
@@ -405,7 +405,7 @@ def test_direct_token_mapping(gravity):
         CONTRACTS["TestERC20Utility"],
     )
     print("crc21 contract", crc21.address)
-    denom = f"gravity{erc20.address}"
+    denom = f"gravity{erc20.address.lower()}"
 
     print("check the contract mapping not exists yet")
     with pytest.raises(AssertionError):
@@ -464,7 +464,7 @@ def test_gravity_cancel_transfer(gravity):
         send_to_cosmos(gravity.contract, erc20, community, amount, KEYS["validator"])
         assert erc20.caller.balanceOf(ADDRS["validator"]) == balance - amount
 
-        denom = f"gravity{erc20.address}"
+        denom = f"gravity{erc20.address.lower()}"
         crc21_contract = None
 
         def local_check_auto_deployment():
@@ -527,7 +527,7 @@ def test_gravity_source_tokens(gravity):
         cronos_cli = gravity.cronos.cosmos_cli()
 
         print("crc21 contract", contract.address)
-        denom = f"cronos{contract.address}"
+        denom = f"cronos{contract.address.lower()}"
 
         print("check the contract mapping not exists yet")
         with pytest.raises(AssertionError):

--- a/integration_tests/test_gravity.py
+++ b/integration_tests/test_gravity.py
@@ -5,7 +5,7 @@ import sha3
 import toml
 from dateutil.parser import isoparse
 from eth_account.account import Account
-from eth_utils import abi
+from eth_utils import abi, to_checksum_address
 from hexbytes import HexBytes
 from pystarport import ports
 from web3.exceptions import BadFunctionCallOutput
@@ -157,7 +157,7 @@ def gravity(cronos, geth):
         gorc.add_eth_key("cronos")  # cronos and eth key derivation are the same
 
         # fund the orchestrator accounts
-        eth_addr = gorc.show_eth_addr("eth")
+        eth_addr = to_checksum_address(gorc.show_eth_addr("eth"))
         print("fund 0.1 eth to address", eth_addr)
         send_transaction(geth, {"to": eth_addr, "value": 10**17}, KEYS["validator"])
         acc_addr = gorc.show_cosmos_addr("cronos")

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -57,7 +57,7 @@ import sources.nixpkgs {
       };
       hermes = pkgs.callPackage ./hermes.nix { src = sources.ibc-rs; };
     })
-    (_: pkgs: { test-env = import ./testenv.nix { inherit pkgs; }; })
+    (_: pkgs: { test-env = pkgs.callPackage ./testenv.nix { }; })
     (final: _: {
       rocksdb = final.callPackage ./rocksdb.nix { enableJemalloc = true; };
     })

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -44,7 +44,7 @@ import sources.nixpkgs {
         name = "gorc";
         src = sources.gravity-bridge;
         sourceRoot = "gravity-bridge-src/orchestrator";
-        cargoSha256 = "sha256-ufrwiXlb0RVaJiJ70TCNblhOUCIj7Jht5kX8SoXQQMA";
+        cargoSha256 = "sha256-FQ43PFGbagIi+KZ6KUtjF7OClIkCqKd4pGzHaYr2Q+A=";
         cargoBuildFlags = "-p ${name} --features ethermint";
         buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin
           (with pkgs.darwin.apple_sdk.frameworks; [ CoreFoundation Security ]);

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -12,8 +12,15 @@ in
 import sources.nixpkgs {
   overlays = [
     (_: pkgs: dapptools) # use released version to hit the binary cache
-    (_: pkgs: {
-      go = pkgs.go_1_18;
+    (final: pkgs: rec {
+      go_1_19 = pkgs.go_1_19.overrideAttrs (_: rec {
+        version = "1.19.6";
+        src = final.fetchurl {
+          url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
+          hash = "sha256-1/ABP4Lm1/hizGy1yM20ju9fLiObNbqpfi8adGYEN2c=";
+        };
+      });
+      go = go_1_19;
       go-ethereum = pkgs.callPackage ./go-ethereum.nix {
         inherit (pkgs.darwin) libobjc;
         inherit (pkgs.darwin.apple_sdk.frameworks) IOKit;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -16,7 +16,7 @@ import sources.nixpkgs {
       go_1_19 = pkgs.go_1_19.overrideAttrs (_: rec {
         version = "1.19.6";
         src = final.fetchurl {
-          url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
+          url = "https://go.dev/dl/go${version}.src.tar.gz";
           hash = "sha256-1/ABP4Lm1/hizGy1yM20ju9fLiObNbqpfi8adGYEN2c=";
         };
       });

--- a/nix/hermes.nix
+++ b/nix/hermes.nix
@@ -9,7 +9,7 @@
 rustPlatform.buildRustPackage rec {
   name = "hermes";
   inherit src;
-  cargoSha256 = "sha256-42yTWf7fFEko0n/Y7AA2vA2s/gMypcZDvbbd9DAcuRw=";
+  cargoSha256 = "sha256-DBHDJlD2kTUeU0LCG5ZUij+v+lWUYRPGVvUKUYPfYQA=";
   cargoBuildFlags = "-p ibc-relayer-cli";
   buildInputs = lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -97,15 +97,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "master",
+        "branch": "release-22.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5342fc6fb59d0595d26883c3cadff16ce58e44f3",
-        "sha256": "1faw05sd10vqvmywjq8j1cvwknqv2yfgg2zgdja32y38z15vj56d",
+        "rev": "fd00212f449f62cf5ec51dc782dae36572142140",
+        "sha256": "0rcqqb08y7p3k854rjszfjvh0v6961l76jr3k9gp30dk2m2fybzb",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5342fc6fb59d0595d26883c3cadff16ce58e44f3.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fd00212f449f62cf5ec51dc782dae36572142140.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -73,15 +73,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ibc-rs": {
-        "branch": "feemarket",
-        "description": "IBC Relayer (Hermes) and Modules in Rust",
+        "branch": "v1.1.0",
+        "description": "IBC modules and relayer - Formal specifications and Rust implementation",
         "homepage": "",
-        "owner": "yihuang",
+        "owner": "informalsystems",
         "repo": "ibc-rs",
-        "rev": "e33cceaa247d5eda7650c24bd3968dea6a05248a",
-        "sha256": "1kq73qvhdz35pxcx07rqqygvb3n8z8wsgw8knddj2b1x3yj66444",
+        "rev": "0daa3e16431e748c96a3fa4ad5e9698074e09060",
+        "sha256": "1fp4hz390fd4nlkrkzdmypy9i83i57l21hg7l0d9xi8h1hjginam",
         "type": "tarball",
-        "url": "https://github.com/yihuang/ibc-rs/archive/e33cceaa247d5eda7650c24bd3968dea6a05248a.tar.gz",
+        "url": "https://github.com/informalsystems/ibc-rs/archive/0daa3e16431e748c96a3fa4ad5e9698074e09060.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -66,10 +66,10 @@
         "homepage": "",
         "owner": "crypto-org-chain",
         "repo": "gravity-bridge",
-        "rev": "3d5bdc8af5227588d04064132335932ee88f57c3",
-        "sha256": "1nn8p4wqg1dx12nf05gm8rw3n02yqssgfsxrlj3c00qzwys6i9y2",
+        "rev": "d984b1562242efab5d7595d4108472ed27eba06f",
+        "sha256": "0q69yysg3ynq5wz98rvg1p8lav1xcrkkn32rxbqmpmffqqi7yv88",
         "type": "tarball",
-        "url": "https://github.com/crypto-org-chain/gravity-bridge/archive/3d5bdc8af5227588d04064132335932ee88f57c3.tar.gz",
+        "url": "https://github.com/crypto-org-chain/gravity-bridge/archive/d984b1562242efab5d7595d4108472ed27eba06f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ibc-rs": {

--- a/nix/testenv.nix
+++ b/nix/testenv.nix
@@ -28,6 +28,11 @@ poetry2nix.mkPoetryEnv {
           substituteInPlace setup.py --replace \'setuptools-markdown\' ""
         '';
       };
+      pyyaml-include = super.pyyaml-include.overridePythonAttrs {
+        preConfigure = ''
+          substituteInPlace setup.py --replace "setup()" "setup(version=\"1.3\")"
+        '';
+      };
     })
   ]);
 }

--- a/nix/testenv.nix
+++ b/nix/testenv.nix
@@ -1,12 +1,33 @@
-{ pkgs }:
-pkgs.poetry2nix.mkPoetryEnv {
+{ poetry2nix, python39, lib }:
+poetry2nix.mkPoetryEnv {
   projectDir = ../integration_tests;
-  python = pkgs.python39;
-  overrides = pkgs.poetry2nix.overrides.withDefaults (self: super: {
-    eth-bloom = super.eth-bloom.overridePythonAttrs {
-      preConfigure = ''
-        substituteInPlace setup.py --replace \'setuptools-markdown\' ""
-      '';
-    };
-  });
+  python = python39;
+  overrides = poetry2nix.overrides.withDefaults (lib.composeManyExtensions [
+    (self: super:
+      let
+        buildSystems = {
+          eth-bloom = [ "setuptools" ];
+          cprotobuf = [ "setuptools" ];
+          durations = [ "setuptools" ];
+          multitail2 = [ "setuptools" ];
+          pytest-github-actions-annotate-failures = [ "setuptools" ];
+          flake8-black = [ "setuptools" ];
+          multiaddr = [ "setuptools" ];
+        };
+      in
+      lib.mapAttrs
+        (attr: systems: super.${attr}.overridePythonAttrs
+          (old: {
+            nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ map (a: self.${a}) systems;
+          }))
+        buildSystems
+    )
+    (self: super: {
+      eth-bloom = super.eth-bloom.overridePythonAttrs {
+        preConfigure = ''
+          substituteInPlace setup.py --replace \'setuptools-markdown\' ""
+        '';
+      };
+    })
+  ]);
 }

--- a/versiondb/go.mod
+++ b/versiondb/go.mod
@@ -1,6 +1,6 @@
 module github.com/crypto-org-chain/cronos/versiondb
 
-go 1.18
+go 1.19
 
 require (
 	cosmossdk.io/errors v1.0.0-beta.7


### PR DESCRIPTION
Solution:
- update nixpksg to release-22.11
- manually patch golang version

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)

