### PR TITLE
Problem: released linux binaries don't use static linking (backport #949)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - [#936](https://github.com/crypto-org-chain/cronos/pull/936) Reuse recovered sender address to optimize performance ([ethermint commit](https://github.com/crypto-org-chain/ethermint/commit/cb741e1d819683795aa32e286d31d8155f903cae)).
+- [#949](https://github.com/crypto-org-chain/cronos/pull/949) Release static-linked binaries for linux platform.
 
 ### Bug Fixes
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,9 +13,19 @@ build() {
     name="$3"
     pkg="cronosd${network}-${build_type}"
     if [[ "$host" == "native" ]]; then
-        FLAKE="${baseurl}#${pkg}"
+        if [[ "${build_platform: -6}" == "-linux" ]]; then
+            # static link for linux targets
+            FLAKE="${baseurl}#legacyPackages.${build_platform}.pkgsStatic.cronos-matrix.${pkg}"
+        else
+            FLAKE="${baseurl}#${pkg}"
+        fi
     else
-        FLAKE="${baseurl}#legacyPackages.${build_platform}.pkgsCross.${host}.cronos-matrix.${pkg}"
+        if [[ "$host" == "aarch64-multiplatform" || "$host" == "gnu64" ]]; then
+            # static link for linux targets
+            FLAKE="${baseurl}#legacyPackages.${build_platform}.pkgsCross.${host}.pkgsStatic.cronos-matrix.${pkg}"
+        else
+            FLAKE="${baseurl}#legacyPackages.${build_platform}.pkgsCross.${host}.cronos-matrix.${pkg}"
+        fi
     fi
     echo "building $FLAKE"
     nix build -L "$FLAKE"


### PR DESCRIPTION
Solution:
- use static-linking in release script

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)

