### PR TITLE
Problem: memiavl fail to run state sync

### DIFF
--- a/memiavl/snapshot.go
+++ b/memiavl/snapshot.go
@@ -213,10 +213,17 @@ func (snapshot *Snapshot) Version() uint32 {
 
 // RootNode returns the root node
 func (snapshot *Snapshot) RootNode() PersistedNode {
-	if snapshot.rootIndex == EmptyRootNodeIndex {
+	if snapshot.IsEmpty() {
 		panic("RootNode not supported on an empty snapshot")
 	}
 	return snapshot.Node(snapshot.rootIndex)
+}
+
+func (snapshot *Snapshot) RootHash() []byte {
+	if snapshot.IsEmpty() {
+		return emptyHash
+	}
+	return snapshot.RootNode().Hash()
 }
 
 // nodesLen returns the number of nodes in the snapshot


### PR DESCRIPTION
Solution:
- override cms before the other options, so the custom cms is always used
- fix importer close
- write metadata file when import

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)

