### PR TITLE
Problem: wal write is heavy in block replaying

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -151,7 +151,8 @@ const (
 	// NOTE: In the SDK, the default value is 255.
 	AddrLen = 20
 
-	FlagMemIAVL = "memiavl"
+	FlagMemIAVL  = "store.memiavl"
+	FlagAsyncWAL = "store.async-wal"
 )
 
 // this line is used by starport scaffolding # stargate/wasm/app/enabledProposals
@@ -350,6 +351,7 @@ func New(
 		// cms must be overridden before the other options, because they may use the cms,
 		// FIXME we are assuming the cms won't be overridden by the other options, but we can't be sure.
 		cms := rootmulti.NewStore(filepath.Join(homePath, "data", "memiavl.db"), logger)
+		cms.SetAsyncWAL(cast.ToBool(appOpts.Get(FlagAsyncWAL)))
 		baseAppOptions = append([]func(*baseapp.BaseApp){setCMS(cms)}, baseAppOptions...)
 	}
 

--- a/integration_tests/configs/default.jsonnet
+++ b/integration_tests/configs/default.jsonnet
@@ -27,8 +27,8 @@
       staked: '1000000000000000000stake',
       mnemonic: '${VALIDATOR1_MNEMONIC}',
       'app-config': {
-        memiavl: true,
         store: {
+          memiavl: true,
           streamers: ['versiondb'],
         },
       },

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -172,7 +172,7 @@ func (db *DB) ApplyUpgrades(upgrades []*TreeNameUpgrade) error {
 func (db *DB) checkAsyncTasks() error {
 	return errors.Join(
 		db.checkAsyncWAL(),
-		db.cleanupSnapshotRewrite(),
+		db.checkBackgroundSnapshotRewrite(),
 	)
 }
 
@@ -188,8 +188,8 @@ func (db *DB) checkAsyncWAL() error {
 	return nil
 }
 
-// cleanupSnapshotRewrite check the result of background snapshot rewrite, cleans up the old snapshots and switches to a new multitree
-func (db *DB) cleanupSnapshotRewrite() error {
+// checkBackgroundSnapshotRewrite check the result of background snapshot rewrite, cleans up the old snapshots and switches to a new multitree
+func (db *DB) checkBackgroundSnapshotRewrite() error {
 	// check the completeness of background snapshot rewriting
 	select {
 	case result := <-db.snapshotRewriteChan:

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -38,7 +38,11 @@ type DB struct {
 	pruneSnapshotLock   sync.Mutex
 
 	// invariant: the LastIndex always match the current version of MultiTree
-	wal             *wal.Log
+	wal     *wal.Log
+	walChan chan *walEntry
+	walQuit chan error
+
+	// pending store upgrades, will be written into WAL in next Commit call
 	pendingUpgrades []*TreeNameUpgrade
 
 	// The assumptions to concurrency:
@@ -59,6 +63,8 @@ type Options struct {
 	SnapshotKeepRecent uint32
 	// load the target version instead of latest version
 	TargetVersion uint32
+	// Write WAL asynchronously, it's ok in blockchain case because we can always replay the raw blocks.
+	AsyncWAL bool
 }
 
 const (
@@ -89,10 +95,30 @@ func Load(dir string, opts Options) (*DB, error) {
 		return nil, err
 	}
 
+	var (
+		walChan chan *walEntry
+		walQuit chan error
+	)
+	if opts.AsyncWAL {
+		walChan = make(chan *walEntry, 100)
+		walQuit = make(chan error)
+		go func() {
+			defer close(walQuit)
+			for entry := range walChan {
+				if err := wal.Write(entry.index, entry.data); err != nil {
+					walQuit <- err
+					return
+				}
+			}
+		}()
+	}
+
 	db := &DB{
 		MultiTree:          *mtree,
 		dir:                dir,
 		wal:                wal,
+		walChan:            walChan,
+		walQuit:            walQuit,
 		snapshotKeepRecent: opts.SnapshotKeepRecent,
 	}
 
@@ -142,13 +168,28 @@ func (db *DB) ApplyUpgrades(upgrades []*TreeNameUpgrade) error {
 	return nil
 }
 
-// cleanupSnapshotRewrite cleans up the old snapshots and switches to a new multitree
-// if a snapshot rewrite is in progress. It returns true if a snapshot rewrite has completed
-// and false otherwise, along with any error encountered during the cleanup process.
-func (db *DB) cleanupSnapshotRewrite() (bool, error) {
-	if db.snapshotRewriteChan == nil {
-		return false, nil
+// checkAsyncTasks checks the status of background tasks non-blocking-ly and process the result
+func (db *DB) checkAsyncTasks() error {
+	return errors.Join(
+		db.checkAsyncWAL(),
+		db.cleanupSnapshotRewrite(),
+	)
+}
+
+// checkAsyncWAL check the quit signal of async wal writing
+func (db *DB) checkAsyncWAL() error {
+	select {
+	case err := <-db.walQuit:
+		// async wal writing failed, we need to abort the state machine
+		return fmt.Errorf("async wal writing goroutine quit unexpectedly: %w", err)
+	default:
 	}
+
+	return nil
+}
+
+// cleanupSnapshotRewrite check the result of background snapshot rewrite, cleans up the old snapshots and switches to a new multitree
+func (db *DB) cleanupSnapshotRewrite() error {
 	// check the completeness of background snapshot rewriting
 	select {
 	case result := <-db.snapshotRewriteChan:
@@ -156,15 +197,15 @@ func (db *DB) cleanupSnapshotRewrite() (bool, error) {
 
 		if result.mtree == nil {
 			// background snapshot rewrite failed
-			return true, fmt.Errorf("background snapshot rewriting failed: %w", result.err)
+			return fmt.Errorf("background snapshot rewriting failed: %w", result.err)
 		}
 
 		// snapshot rewrite succeeded, catchup and switch
 		if err := result.mtree.CatchupWAL(db.wal, 0); err != nil {
-			return true, fmt.Errorf("catchup failed: %w", err)
+			return fmt.Errorf("catchup failed: %w", err)
 		}
 		if err := db.reloadMultiTree(result.mtree); err != nil {
-			return true, fmt.Errorf("switch multitree failed: %w", err)
+			return fmt.Errorf("switch multitree failed: %w", err)
 		}
 		// prune the old snapshots
 		// wait until last prune finish
@@ -176,12 +217,12 @@ func (db *DB) cleanupSnapshotRewrite() (bool, error) {
 			if err == nil {
 				for _, entry := range entries {
 					if entry.IsDir() && strings.HasPrefix(entry.Name(), SnapshotPrefix) {
-						currentVersion, err := strconv.ParseUint(strings.TrimPrefix(entry.Name(), SnapshotPrefix), 10, 32)
+						currentVersion, err := strconv.ParseInt(strings.TrimPrefix(entry.Name(), SnapshotPrefix), 10, 32)
 						if err != nil {
 							fmt.Printf("failed when parse current version: %s\n", err)
 							continue
 						}
-						if result.version-uint32(currentVersion) > db.snapshotKeepRecent {
+						if result.mtree.metadata.CommitInfo.Version-currentVersion > int64(db.snapshotKeepRecent) {
 							fullPath := filepath.Join(db.dir, entry.Name())
 							if err := os.RemoveAll(fullPath); err != nil {
 								fmt.Printf("failed when remove old snapshot: %s\n", err)
@@ -191,11 +232,11 @@ func (db *DB) cleanupSnapshotRewrite() (bool, error) {
 				}
 			}
 		}()
-		return true, nil
+		return nil
 
 	default:
 	}
-	return false, nil
+	return nil
 }
 
 // Commit wraps `MultiTree.ApplyChangeSet` to add some db level operations:
@@ -205,7 +246,7 @@ func (db *DB) Commit(changeSets []*NamedChangeSet) ([]byte, int64, error) {
 	db.mtx.Lock()
 	defer db.mtx.Unlock()
 
-	if _, err := db.cleanupSnapshotRewrite(); err != nil {
+	if err := db.checkAsyncTasks(); err != nil {
 		return nil, 0, err
 	}
 
@@ -216,16 +257,23 @@ func (db *DB) Commit(changeSets []*NamedChangeSet) ([]byte, int64, error) {
 
 	if db.wal != nil {
 		// write write-ahead-log
-		entry := WALEntry{
+		o := WALEntry{
 			Changesets: changeSets,
 			Upgrades:   db.pendingUpgrades,
 		}
-		bz, err := entry.Marshal()
+		bz, err := o.Marshal()
 		if err != nil {
 			return nil, 0, err
 		}
-		if err := db.wal.Write(walIndex(v, db.initialVersion), bz); err != nil {
-			return nil, 0, err
+
+		entry := walEntry{index: walIndex(v, db.initialVersion), data: bz}
+		if db.walChan != nil {
+			// async wal writing
+			db.walChan <- &entry
+		} else {
+			if err := db.wal.Write(entry.index, entry.data); err != nil {
+				return nil, 0, err
+			}
 		}
 	}
 
@@ -345,7 +393,16 @@ func (db *DB) Close() error {
 	db.mtx.Lock()
 	defer db.mtx.Unlock()
 
-	return errors.Join(db.MultiTree.Close(), db.wal.Close())
+	var walErr error
+	if db.walChan != nil {
+		close(db.walChan)
+		walErr = <-db.walQuit
+
+		db.walChan = nil
+		db.walQuit = nil
+	}
+
+	return errors.Join(db.MultiTree.Close(), db.wal.Close(), walErr)
 }
 
 // TreeByName wraps MultiTree.TreeByName to add a lock.
@@ -451,4 +508,9 @@ func updateCurrentSymlink(dir, snapshot string) error {
 	}
 	// assuming file renaming operation is atomic
 	return os.Rename(tmpPath, currentPath(dir))
+}
+
+type walEntry struct {
+	index uint64
+	data  []byte
 }

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -49,6 +49,8 @@ type Store struct {
 	listeners    map[types.StoreKey][]types.WriteListener
 
 	interBlockCache types.MultiStorePersistentCache
+
+	asyncWAL bool
 }
 
 func NewStore(dir string, logger log.Logger) *Store {
@@ -268,6 +270,7 @@ func (rs *Store) LoadVersionAndUpgrade(version int64, upgrades *types.StoreUpgra
 		CreateIfMissing: true,
 		InitialStores:   initialStores,
 		TargetVersion:   uint32(version),
+		AsyncWAL:        rs.asyncWAL,
 	})
 	if err != nil {
 		return errors.Wrapf(err, "fail to load memiavl at %s", rs.dir)
@@ -379,6 +382,10 @@ func (rs *Store) SetIAVLDisableFastNode(disable bool) {
 
 // Implements interface CommitMultiStore
 func (rs *Store) SetLazyLoading(lazyLoading bool) {
+}
+
+func (rs *Store) SetAsyncWAL(async bool) {
+	rs.asyncWAL = async
 }
 
 // Implements interface CommitMultiStore


### PR DESCRIPTION
Solution:
    - introduce `store.async-wal` option to write wal asynchronously
    - rename the `memiavl` flag to `store.memiavl`.

In the block replaying test, it reduce the sync time from 2m to 1m10s, 40% reduction.

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)

