### PR TITLE
Problem: memiavl result is different when replaying write-ahead-log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#1075](https://github.com/crypto-org-chain/cronos/pull/1075) Add missing close in memiavl to avoid resource leaks.
 - [#1073](https://github.com/crypto-org-chain/cronos/pull/1073) memiavl automatically truncate corrupted wal tail.
 - [#1087](https://github.com/crypto-org-chain/cronos/pull/1087) memiavl fix LastCommitID when memiavl db not loaded.
+- [#1088](https://github.com/crypto-org-chain/cronos/pull/1088) memiavl fix empty value in write-ahead-log replaying.
 
 ### Features
 

--- a/app/app.go
+++ b/app/app.go
@@ -999,7 +999,7 @@ func VerifyAddressFormat(bz []byte) error {
 // Close will be called in graceful shutdown in start cmd
 func (app *App) Close() error {
 	if cms, ok := app.CommitMultiStore().(*memiavlrootmulti.Store); ok {
-		return cms.WaitAsyncCommit()
+		return cms.Close()
 	}
 
 	return nil

--- a/memiavl/tree.go
+++ b/memiavl/tree.go
@@ -123,6 +123,10 @@ func (t *Tree) ApplyChangeSet(changeSet iavl.ChangeSet, updateHash bool) ([]byte
 }
 
 func (t *Tree) set(key, value []byte) {
+	if value == nil {
+		// the value could be nil when replaying changes from write-ahead-log because of protobuf decoding
+		value = []byte{}
+	}
 	t.root, _ = setRecursive(t.root, key, value, t.version+1, t.cowVersion)
 	t.cache.Add(&cacheNode{key, value})
 }

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -108,8 +108,8 @@ func (rs *Store) Commit() types.CommitID {
 	return rs.lastCommitInfo.CommitID()
 }
 
-func (rs *Store) WaitAsyncCommit() error {
-	return rs.db.WaitAsyncCommit()
+func (rs *Store) Close() error {
+	return rs.db.Close()
 }
 
 // Implements interface Committer


### PR DESCRIPTION
if there are empty values, because protobuf decodes empty value as `nil`.

Solution:
- make sure empty value is represented as empty slice instead of nil in set operation.

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)

