### PR TITLE
Problem: concurrent map access in multistore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,7 @@ jobs:
         with:
           name: cronos
           extraPullNames: dapp
+          installCommand: "nix-env --quiet -j8 -iA cachix -f https://cachix.org/api/v1/install/1.6.1"
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
       - name: test contracts
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           name: cronos
           extraPullNames: dapp
+          installCommand: "nix-env --quiet -j8 -iA cachix -f https://cachix.org/api/v1/install/1.6.1"
           # github don't pass secrets for pull request from fork repos,
           # in that case the push is disabled naturally.
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
@@ -101,6 +102,7 @@ jobs:
         with:
           name: cronos
           extraPullNames: dapp
+          installCommand: "nix-env --quiet -j8 -iA cachix -f https://cachix.org/api/v1/install/1.6.1"
           # github don't pass secrets for pull request from fork repos,
           # in that case the push is disabled naturally.
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## UNRELEASED
+
+- [#](https://github.com/crypto-org-chain/cronos/pull/) Avoid concurrent map access in multistore on grpc call.
+
+
 *January 5, 2024*
 
 ## v1.1.0-rc2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- [#](https://github.com/crypto-org-chain/cronos/pull/) Avoid concurrent map access in multistore on grpc call.
+- [#1299](https://github.com/crypto-org-chain/cronos/pull/1299) Avoid concurrent map access in multistore on grpc call.
 
 
 *January 5, 2024*

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -221,11 +221,13 @@ func (rs *Store) CacheMultiStoreWithVersion(version int64) (types.CacheMultiStor
 	stores := make(map[types.StoreKey]types.CacheWrapper)
 
 	// add the transient/mem stores registered in current app.
+	rs.mtx.RLock()
 	for k, store := range rs.stores {
 		if store.GetStoreType() != types.StoreTypeIAVL {
 			stores[k] = store
 		}
 	}
+	rs.mtx.RUnlock()
 
 	// add all the iavl stores at the target version.
 	for _, tree := range db.Trees() {

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -370,7 +370,9 @@ func (rs *Store) LoadVersionAndUpgrade(version int64, upgrades *types.StoreUpgra
 	}
 
 	rs.db = db
+	rs.mtx.Lock()
 	rs.stores = newStores
+	rs.mtx.Unlock()
 	// to keep the root hash compatible with cosmos-sdk 0.46
 	if db.Version() != 0 {
 		rs.lastCommitInfo = convertCommitInfo(db.LastCommitInfo())

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -296,6 +296,8 @@ func (rs *Store) GetCommitStore(key types.StoreKey) types.CommitStore {
 
 // Implements interface CommitMultiStore
 func (rs *Store) GetCommitKVStore(key types.StoreKey) types.CommitKVStore {
+	rs.mtx.RLock()
+	defer rs.mtx.RUnlock()
 	return rs.stores[key]
 }
 

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -190,6 +190,7 @@ func (rs *Store) CacheWrapWithTrace(_ io.Writer, _ types.TraceContext) types.Cac
 // Implements interface MultiStore
 func (rs *Store) CacheMultiStore() types.CacheMultiStore {
 	stores := make(map[types.StoreKey]types.CacheWrapper)
+	rs.mtx.RLock()
 	for k, v := range rs.stores {
 		store := types.KVStore(v)
 		// Wire the listenkv.Store to allow listeners to observe the writes from the cache store,
@@ -199,6 +200,7 @@ func (rs *Store) CacheMultiStore() types.CacheMultiStore {
 		}
 		stores[k] = store
 	}
+	rs.mtx.RUnlock()
 	return cachemulti.NewStore(nil, stores, rs.keysByName, nil, nil, nil)
 }
 

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -72,6 +72,7 @@ func NewStore(dir string, logger log.Logger, sdk46Compact bool, supportExportNon
 // flush writes all the pending change sets to memiavl tree.
 func (rs *Store) flush() error {
 	var changeSets []*memiavl.NamedChangeSet
+	rs.mtx.RLock()
 	for key := range rs.stores {
 		// it'll unwrap the inter-block cache
 		store := rs.GetCommitKVStore(key)
@@ -85,6 +86,7 @@ func (rs *Store) flush() error {
 			}
 		}
 	}
+	rs.mtx.RUnlock()
 	sort.SliceStable(changeSets, func(i, j int) bool {
 		return changeSets[i].Name < changeSets[j].Name
 	})

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -73,9 +73,8 @@ func NewStore(dir string, logger log.Logger, sdk46Compact bool, supportExportNon
 func (rs *Store) flush() error {
 	var changeSets []*memiavl.NamedChangeSet
 	rs.mtx.RLock()
-	for key := range rs.stores {
+	for key, store := range rs.stores {
 		// it'll unwrap the inter-block cache
-		store := rs.GetCommitKVStore(key)
 		if memiavlStore, ok := store.(*memiavlstore.Store); ok {
 			cs := memiavlStore.PopChangeSet()
 			if len(cs.Pairs) > 0 {

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -113,12 +113,13 @@ func (rs *Store) Commit() types.CommitID {
 	if err := rs.flush(); err != nil {
 		panic(err)
 	}
-
+	rs.mtx.RLock()
 	for _, store := range rs.stores {
 		if store.GetStoreType() != types.StoreTypeIAVL {
 			_ = store.Commit()
 		}
 	}
+	rs.mtx.RUnlock()
 
 	_, err := rs.db.Commit()
 	if err != nil {


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced thread-safety in store operations with the addition of mutex locks.

- **Chores**
  - Updated build and test workflow configurations with new `installCommand` parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->