### PR TITLE
Problem: cosmovisor in test is out dated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Improvements
+
+* (test) [#1380](https://github.com/crypto-org-chain/cronos/pull/1380) Upgrade cosmovisor to 1.5.0 in integration test.
+
 *April 8, 2024*
 
 ## v1.2.0-rc1

--- a/flake.nix
+++ b/flake.nix
@@ -81,16 +81,6 @@
         go = super.go_1_22;
         test-env = final.callPackage ./nix/testenv.nix { };
         bundle-exe = final.pkgsBuildBuild.callPackage nix-bundle-exe { };
-        # make-tarball don't follow symbolic links to avoid duplicate file, the bundle should have no external references.
-        # reset the ownership and permissions to make the extract result more normal.
-        make-tarball = drv: final.runCommand "tarball-${drv.name}"
-          {
-            nativeBuildInputs = with final.buildPackages; [ gnutar gzip ];
-          } ''
-          tar cfv - -C "${drv}" \
-            --owner=0 --group=0 --mode=u+rw,uga+r --hard-dereference . \
-            | gzip -9 > $out
-        '';
         bundle-win-exe = drv: final.callPackage ./nix/bundle-win-exe.nix { cronosd = drv; };
       } // (with final;
         let

--- a/integration_tests/configs/upgrade-test-package.nix
+++ b/integration_tests/configs/upgrade-test-package.nix
@@ -19,9 +19,10 @@ let
   # v1.1.1
   released = (fetchFlake "crypto-org-chain/cronos" "10b8eeb9052e3c52aa59dec15f5d3aca781d1271").default;
   current = pkgs.callPackage ../../. { };
+  farm = pkgs.linkFarm "upgrade-test-package" [
+    { name = "genesis/bin"; path = "${released0}/bin"; }
+    { name = "v1.1.0/bin"; path = "${released}/bin"; }
+    { name = "v1.2/bin"; path = "${current}/bin"; }
+  ];
 in
-pkgs.linkFarm "upgrade-test-package" [
-  { name = "genesis"; path = released0; }
-  { name = "v1.1.0"; path = released; }
-  { name = "v1.2"; path = current; }
-]
+pkgs.make-tarball farm

--- a/nix/build_overlay.nix
+++ b/nix/build_overlay.nix
@@ -1,4 +1,21 @@
 # some basic overlays nessesary for the build
 final: super: {
   rocksdb = final.callPackage ./rocksdb.nix { };
+
+  # make-tarball don't follow symbolic links to avoid duplicate file, the bundle should have no external references.
+  # reset the ownership and permissions to make the extract result more normal.
+  make-tarball = final.callPackage
+    ({ buildPackages
+     , runCommand
+     }: drv: runCommand "tarball-${drv.name}"
+      {
+        nativeBuildInputs = with buildPackages; [ gnutar gzip ];
+      }
+      ''
+        tar cfv - -C "${drv}" \
+          --owner=0 --group=0 --mode=u+rw,uga+r --hard-dereference . \
+          | gzip -9 > $out
+      ''
+    )
+    { };
 }

--- a/nix/cosmovisor.nix
+++ b/nix/cosmovisor.nix
@@ -1,0 +1,21 @@
+{ buildGoModule
+, fetchFromGitHub
+}:
+
+let
+  version = "1.5.0";
+  cosmos-sdk = fetchFromGitHub {
+    owner = "cosmos";
+    repo = "cosmos-sdk";
+    rev = "tools/cosmovisor/v${version}";
+    hash = "sha256-Ov8FGpDOcsqmFLT2s/ubjmTXj17sQjBWRAdxlJ6DNEY=";
+  };
+in
+buildGoModule rec {
+  name = "cosmovisor";
+  version = "1.5.0";
+  src = cosmos-sdk + "/tools/cosmovisor";
+  subPackages = [ "./cmd/cosmovisor" ];
+  vendorHash = "sha256-IkPnnfkofn5w8Oa/uzGxgI1eb5RrJ9haNgj4mBXF+n8=";
+  doCheck = false;
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -44,13 +44,7 @@ import sources.nixpkgs {
     })
     (_: pkgs: { test-env = pkgs.callPackage ./testenv.nix { }; })
     (_: pkgs: {
-      cosmovisor = pkgs.buildGo120Module rec {
-        name = "cosmovisor";
-        src = sources.cosmos-sdk + "/cosmovisor";
-        subPackages = [ "./cmd/cosmovisor" ];
-        vendorHash = "sha256-OAXWrwpartjgSP7oeNvDJ7cTR9lyYVNhEM8HUnv3acE=";
-        doCheck = false;
-      };
+      cosmovisor = pkgs.callPackage ./cosmovisor.nix { };
     })
     (_: pkgs: {
       rly = pkgs.buildGo120Module rec {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,18 +11,6 @@
         "url": "https://github.com/crypto-org-chain/chain-main/archive/04e8e094b7d51a8cf92b74c789394b7b34987b10.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "cosmos-sdk": {
-        "branch": "v0.45.0",
-        "description": ":chains: A Framework for Building High Value Public Blockchains :sparkles:",
-        "homepage": "https://cosmos.network/",
-        "owner": "cosmos",
-        "repo": "cosmos-sdk",
-        "rev": "b6c77e6c819f8a51166649eaef125d1bfb276f04",
-        "sha256": "09ns4yfxyfi7c7n5g69zv32m1rdssdl48c1akmv1y2vz6ayz4v02",
-        "type": "tarball",
-        "url": "https://github.com/cosmos/cosmos-sdk/archive/b6c77e6c819f8a51166649eaef125d1bfb276f04.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "dapptools": {
         "branch": "master",
         "description": "Dapp, Seth, Hevm, and more",


### PR DESCRIPTION
new version cosmovisor support graceful shutdown

Solution:
- update cosmovisor
- adapt the test case

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Upgraded Cosmovisor to version 1.5.0 in integration tests.
	- Introduced a new method for creating tarballs without following symbolic links to avoid duplicates and ensure standard extraction results.
- **Bug Fixes**
	- Updated `upgrade-test-package` configuration to correctly include specific versions and directories.
- **Refactor**
	- Simplified the tarball creation logic by removing adjustments related to symbolic links and ownership/permissions.
	- Modified the `cosmovisor start` command to `cosmovisor run start` in integration tests for enhanced functionality.
- **Chores**
	- Removed the `cosmos-sdk` entry from sources, streamlining the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->