### PR TITLE
Problem: global flags are not added

### DIFF
--- a/cmd/cronosd/cmd/root.go
+++ b/cmd/cronosd/cmd/root.go
@@ -42,6 +42,7 @@ import (
 	"github.com/evmos/ethermint/crypto/hd"
 	ethermintserver "github.com/evmos/ethermint/server"
 	servercfg "github.com/evmos/ethermint/server/config"
+	srvflags "github.com/evmos/ethermint/server/flags"
 	ethermint "github.com/evmos/ethermint/types"
 
 	memiavlcfg "github.com/crypto-org-chain/cronos/store/config"
@@ -193,6 +194,10 @@ func initRootCmd(
 		e2eecli.E2EECommand(),
 	)
 
+	rootCmd, err := srvflags.AddGlobalFlags(rootCmd)
+	if err != nil {
+		panic(err)
+	}
 	// add rosetta
 	rootCmd.AddCommand(rosettaCmd.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Codec))
 }

--- a/integration_tests/test_e2ee.py
+++ b/integration_tests/test_e2ee.py
@@ -1,7 +1,9 @@
 def test_register(cronos):
     cli = cronos.cosmos_cli()
     pubkey0 = cli.keygen(keyring_name="key0")
-    cli.register_e2ee_key(pubkey0 + "malformed", _from="validator")
+    rsp = cli.register_e2ee_key(pubkey0 + "malformed", _from="validator")
+    assert rsp["code"] != 0
+    assert "malformed recipient" in rsp["raw_log"]
     assert not cli.query_e2ee_key(cli.address("validator"))
 
 


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced command-line functionality with additional global flags for better customization and error handling.
  
- **Tests**
	- Improved end-to-end testing by verifying error handling in key registration processes to ensure robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->