### PR TITLE
Problem: sig verification result is not cached between incarnations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * (versiondb) [#1498](https://github.com/crypto-org-chain/cronos/pull/1498) Reduce scope of copying slice data in iterator.
 * [#1500](https://github.com/crypto-org-chain/cronos/pull/1500), [#1503](https://github.com/crypto-org-chain/cronos/pull/1503) Set mempool MaxTx from config (with a default value of `3000`).
 * (store) [#1511](https://github.com/crypto-org-chain/cronos/pull/1511) Upgrade rocksdb to `v9.2.1`.
-
+* (block-stm) [#]() Improve performance by cache signature verification result between incarnations of same tx.
 
 *Jun 18, 2024*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * (versiondb) [#1498](https://github.com/crypto-org-chain/cronos/pull/1498) Reduce scope of copying slice data in iterator.
 * [#1500](https://github.com/crypto-org-chain/cronos/pull/1500), [#1503](https://github.com/crypto-org-chain/cronos/pull/1503) Set mempool MaxTx from config (with a default value of `3000`).
 * (store) [#1511](https://github.com/crypto-org-chain/cronos/pull/1511) Upgrade rocksdb to `v9.2.1`.
-* (block-stm) [#]() Improve performance by cache signature verification result between incarnations of same tx.
+* (block-stm) [#1515](https://github.com/crypto-org-chain/cronos/pull/1515) Improve performance by cache signature verification result between incarnations of same tx.
 
 *Jun 18, 2024*
 

--- a/go.mod
+++ b/go.mod
@@ -257,7 +257,7 @@ replace (
 	cosmossdk.io/client/v2 => github.com/crypto-org-chain/cosmos-sdk/client/v2 v2.0.0-20240626040048-36295f051595
 	cosmossdk.io/store => github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20240626040048-36295f051595
 	cosmossdk.io/x/tx => github.com/crypto-org-chain/cosmos-sdk/x/tx v0.0.0-20240626040048-36295f051595
-	github.com/cosmos/cosmos-sdk => github.com/yihuang/cosmos-sdk v0.43.0-beta1.0.20240712031138-3ff3dff0ad1d
+	github.com/cosmos/cosmos-sdk => github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20240715031529-5a1594f17924
 )
 
 replace (

--- a/go.mod
+++ b/go.mod
@@ -171,7 +171,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/ledgerwatch/erigon-lib v0.0.0-20230210071639-db0e7ed11263 // indirect
 	github.com/lib/pq v1.10.7 // indirect
-	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/manifoldco/promptui v0.9.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -257,7 +256,7 @@ replace (
 	cosmossdk.io/client/v2 => github.com/crypto-org-chain/cosmos-sdk/client/v2 v2.0.0-20240626040048-36295f051595
 	cosmossdk.io/store => github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20240626040048-36295f051595
 	cosmossdk.io/x/tx => github.com/crypto-org-chain/cosmos-sdk/x/tx v0.0.0-20240626040048-36295f051595
-	github.com/cosmos/cosmos-sdk => github.com/mmsqe/cosmos-sdk v0.46.0-beta2.0.20240715072401-d2de62e1575e
+	github.com/cosmos/cosmos-sdk => github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20240716063309-c47504d189d4
 )
 
 replace (

--- a/go.mod
+++ b/go.mod
@@ -277,7 +277,8 @@ replace (
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/ethereum/go-ethereum => github.com/crypto-org-chain/go-ethereum v1.10.20-0.20240425065928-ebb09502e7a7
 	// block-stm branch
-	github.com/evmos/ethermint => github.com/yihuang/ethermint v0.6.1-0.20240712032427-2cbbf8551191
+	github.com/evmos/ethermint => github.com/crypto-org-chain/ethermint v0.6.1-0.20240715061533-9c959a26e04f
+
 	// Fix upstream GHSA-h395-qcrw-5vmq and GHSA-3vp4-m3rf-835h vulnerabilities.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -257,7 +257,7 @@ replace (
 	cosmossdk.io/client/v2 => github.com/crypto-org-chain/cosmos-sdk/client/v2 v2.0.0-20240626040048-36295f051595
 	cosmossdk.io/store => github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20240626040048-36295f051595
 	cosmossdk.io/x/tx => github.com/crypto-org-chain/cosmos-sdk/x/tx v0.0.0-20240626040048-36295f051595
-	github.com/cosmos/cosmos-sdk => github.com/crypto-org-chain/cosmos-sdk v0.0.0-20240626040048-36295f051595
+	github.com/cosmos/cosmos-sdk => github.com/yihuang/cosmos-sdk v0.43.0-beta1.0.20240712031138-3ff3dff0ad1d
 )
 
 replace (
@@ -277,7 +277,7 @@ replace (
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/ethereum/go-ethereum => github.com/crypto-org-chain/go-ethereum v1.10.20-0.20240425065928-ebb09502e7a7
 	// block-stm branch
-	github.com/evmos/ethermint => github.com/crypto-org-chain/ethermint v0.6.1-0.20240702125417-e5b222ffaf90
+	github.com/evmos/ethermint => github.com/yihuang/ethermint v0.6.1-0.20240712032427-2cbbf8551191
 	// Fix upstream GHSA-h395-qcrw-5vmq and GHSA-3vp4-m3rf-835h vulnerabilities.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -257,7 +257,7 @@ replace (
 	cosmossdk.io/client/v2 => github.com/crypto-org-chain/cosmos-sdk/client/v2 v2.0.0-20240626040048-36295f051595
 	cosmossdk.io/store => github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20240626040048-36295f051595
 	cosmossdk.io/x/tx => github.com/crypto-org-chain/cosmos-sdk/x/tx v0.0.0-20240626040048-36295f051595
-	github.com/cosmos/cosmos-sdk => github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20240715031529-5a1594f17924
+	github.com/cosmos/cosmos-sdk => github.com/mmsqe/cosmos-sdk v0.46.0-beta2.0.20240715072401-d2de62e1575e
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,6 @@ github.com/crypto-org-chain/btree v0.0.0-20240406140148-2687063b042c h1:MOgfS4+F
 github.com/crypto-org-chain/btree v0.0.0-20240406140148-2687063b042c/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/crypto-org-chain/cometbft-db v0.0.0-20231011055109-57922ac52a63 h1:R1QJ9a3XdYMSKo+1RdFifxb/g3lNypC52L/rpYrWoKo=
 github.com/crypto-org-chain/cometbft-db v0.0.0-20231011055109-57922ac52a63/go.mod h1:rocwIfnS+kA060x64gkSIRvWB9StSppIkJuo5MWzL24=
-github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20240715031529-5a1594f17924 h1:rTiEYiXC8AxKeKsOTz4QODkX9fvMAnlAj8R2gOACoxU=
-github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20240715031529-5a1594f17924/go.mod h1:bIUzWfqXnCF2WTFb2uN+FjzMIG3BsOk+P2QmvMtm4ic=
 github.com/crypto-org-chain/cosmos-sdk/client/v2 v2.0.0-20240626040048-36295f051595 h1:xfrVLBZgV2DXjQXTSlaWHcG/s6Fdeme8tczaN4TTERw=
 github.com/crypto-org-chain/cosmos-sdk/client/v2 v2.0.0-20240626040048-36295f051595/go.mod h1:W5sR4asmVDUhJpEmuXTUBkk/yEefKlXTjVWcNciVSR0=
 github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20240626040048-36295f051595 h1:gHBOTNAuuGeD9HXGkTE04x3zee+00bXcVd8Jb3WG0nY=
@@ -905,6 +903,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/pointerstructure v1.2.0 h1:O+i9nHnXS3l/9Wu7r4NrEdwA2VFTicjUEN1uBnDo34A=
 github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
+github.com/mmsqe/cosmos-sdk v0.46.0-beta2.0.20240715072401-d2de62e1575e h1:WakMRR878Xl89MrYp6TxqIYr8aM5WxuJYn4Qpilh3F8=
+github.com/mmsqe/cosmos-sdk v0.46.0-beta2.0.20240715072401-d2de62e1575e/go.mod h1:Rb43DdB0i/rKcCN69Tg2X3+zA4WhJ7MC8K3a6Ezh38E=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/go.sum
+++ b/go.sum
@@ -422,6 +422,8 @@ github.com/crypto-org-chain/btree v0.0.0-20240406140148-2687063b042c h1:MOgfS4+F
 github.com/crypto-org-chain/btree v0.0.0-20240406140148-2687063b042c/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/crypto-org-chain/cometbft-db v0.0.0-20231011055109-57922ac52a63 h1:R1QJ9a3XdYMSKo+1RdFifxb/g3lNypC52L/rpYrWoKo=
 github.com/crypto-org-chain/cometbft-db v0.0.0-20231011055109-57922ac52a63/go.mod h1:rocwIfnS+kA060x64gkSIRvWB9StSppIkJuo5MWzL24=
+github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20240715031529-5a1594f17924 h1:rTiEYiXC8AxKeKsOTz4QODkX9fvMAnlAj8R2gOACoxU=
+github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20240715031529-5a1594f17924/go.mod h1:bIUzWfqXnCF2WTFb2uN+FjzMIG3BsOk+P2QmvMtm4ic=
 github.com/crypto-org-chain/cosmos-sdk/client/v2 v2.0.0-20240626040048-36295f051595 h1:xfrVLBZgV2DXjQXTSlaWHcG/s6Fdeme8tczaN4TTERw=
 github.com/crypto-org-chain/cosmos-sdk/client/v2 v2.0.0-20240626040048-36295f051595/go.mod h1:W5sR4asmVDUhJpEmuXTUBkk/yEefKlXTjVWcNciVSR0=
 github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20240626040048-36295f051595 h1:gHBOTNAuuGeD9HXGkTE04x3zee+00bXcVd8Jb3WG0nY=
@@ -1160,8 +1162,6 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
-github.com/yihuang/cosmos-sdk v0.43.0-beta1.0.20240712031138-3ff3dff0ad1d h1:nRWDIXU5hAWSd+W+4wPEjlAygBD1ynvdbMieQo3mfyA=
-github.com/yihuang/cosmos-sdk v0.43.0-beta1.0.20240712031138-3ff3dff0ad1d/go.mod h1:bIUzWfqXnCF2WTFb2uN+FjzMIG3BsOk+P2QmvMtm4ic=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -366,8 +366,6 @@ github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZ
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0 h1:jpVIwLcPoOeCR6o1tU+Xv7r5bMONNbHU7MuEHboiFuA=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0/go.mod h1:eq7W2TMRH22GTW0N0beDnN931DW0/WOI1R2sdHNHG4c=
-github.com/cometbft/cometbft v0.38.8 h1:XyJ9Cu3xqap6xtNxiemrO8roXZ+KS2Zlu7qQ0w1trvU=
-github.com/cometbft/cometbft v0.38.8/go.mod h1:xOoGZrtUT+A5izWfHSJgl0gYZUE7lu7Z2XIS1vWG/QQ=
 github.com/cometbft/cometbft v0.38.10-0.20240709120009-0792c8bdda44 h1:Tm6SG54Tj/bGVEZUyFPs2UyG0BYvCO3oqvWNyw99bi4=
 github.com/cometbft/cometbft v0.38.10-0.20240709120009-0792c8bdda44/go.mod h1:jHPx9vQpWzPHEAiYI/7EDKaB1NXhK6o3SArrrY8ExKc=
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=
@@ -424,6 +422,8 @@ github.com/crypto-org-chain/btree v0.0.0-20240406140148-2687063b042c h1:MOgfS4+F
 github.com/crypto-org-chain/btree v0.0.0-20240406140148-2687063b042c/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/crypto-org-chain/cometbft-db v0.0.0-20231011055109-57922ac52a63 h1:R1QJ9a3XdYMSKo+1RdFifxb/g3lNypC52L/rpYrWoKo=
 github.com/crypto-org-chain/cometbft-db v0.0.0-20231011055109-57922ac52a63/go.mod h1:rocwIfnS+kA060x64gkSIRvWB9StSppIkJuo5MWzL24=
+github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20240716063309-c47504d189d4 h1:ipjTVqr7gMct5OQvCmzrNbm7xIxb2wTCLpCXpUf0+KA=
+github.com/crypto-org-chain/cosmos-sdk v0.50.6-0.20240716063309-c47504d189d4/go.mod h1:Rb43DdB0i/rKcCN69Tg2X3+zA4WhJ7MC8K3a6Ezh38E=
 github.com/crypto-org-chain/cosmos-sdk/client/v2 v2.0.0-20240626040048-36295f051595 h1:xfrVLBZgV2DXjQXTSlaWHcG/s6Fdeme8tczaN4TTERw=
 github.com/crypto-org-chain/cosmos-sdk/client/v2 v2.0.0-20240626040048-36295f051595/go.mod h1:W5sR4asmVDUhJpEmuXTUBkk/yEefKlXTjVWcNciVSR0=
 github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20240626040048-36295f051595 h1:gHBOTNAuuGeD9HXGkTE04x3zee+00bXcVd8Jb3WG0nY=
@@ -856,8 +856,6 @@ github.com/ledgerwatch/erigon-lib v0.0.0-20230210071639-db0e7ed11263/go.mod h1:O
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6cdF0Y8=
-github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linxGnu/grocksdb v1.9.2 h1:O3mzvO0wuzQ9mtlHbDrShixyVjVbmuqTjFrzlf43wZ8=
@@ -905,8 +903,6 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/pointerstructure v1.2.0 h1:O+i9nHnXS3l/9Wu7r4NrEdwA2VFTicjUEN1uBnDo34A=
 github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
-github.com/mmsqe/cosmos-sdk v0.46.0-beta2.0.20240715072401-d2de62e1575e h1:WakMRR878Xl89MrYp6TxqIYr8aM5WxuJYn4Qpilh3F8=
-github.com/mmsqe/cosmos-sdk v0.46.0-beta2.0.20240715072401-d2de62e1575e/go.mod h1:Rb43DdB0i/rKcCN69Tg2X3+zA4WhJ7MC8K3a6Ezh38E=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/go.sum
+++ b/go.sum
@@ -422,16 +422,12 @@ github.com/crypto-org-chain/btree v0.0.0-20240406140148-2687063b042c h1:MOgfS4+F
 github.com/crypto-org-chain/btree v0.0.0-20240406140148-2687063b042c/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/crypto-org-chain/cometbft-db v0.0.0-20231011055109-57922ac52a63 h1:R1QJ9a3XdYMSKo+1RdFifxb/g3lNypC52L/rpYrWoKo=
 github.com/crypto-org-chain/cometbft-db v0.0.0-20231011055109-57922ac52a63/go.mod h1:rocwIfnS+kA060x64gkSIRvWB9StSppIkJuo5MWzL24=
-github.com/crypto-org-chain/cosmos-sdk v0.0.0-20240626040048-36295f051595 h1:qiUv1Y+OE8ZgB5mfXFti8R9bjq8zmfuoe2m2g3Iq41c=
-github.com/crypto-org-chain/cosmos-sdk v0.0.0-20240626040048-36295f051595/go.mod h1:bIUzWfqXnCF2WTFb2uN+FjzMIG3BsOk+P2QmvMtm4ic=
 github.com/crypto-org-chain/cosmos-sdk/client/v2 v2.0.0-20240626040048-36295f051595 h1:xfrVLBZgV2DXjQXTSlaWHcG/s6Fdeme8tczaN4TTERw=
 github.com/crypto-org-chain/cosmos-sdk/client/v2 v2.0.0-20240626040048-36295f051595/go.mod h1:W5sR4asmVDUhJpEmuXTUBkk/yEefKlXTjVWcNciVSR0=
 github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20240626040048-36295f051595 h1:gHBOTNAuuGeD9HXGkTE04x3zee+00bXcVd8Jb3WG0nY=
 github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20240626040048-36295f051595/go.mod h1:gjE3DZe4t/+VeIk6CmrouyqiuDbZ7QOVDDq3nLqBTpg=
 github.com/crypto-org-chain/cosmos-sdk/x/tx v0.0.0-20240626040048-36295f051595 h1:MPKv1EzM16dx+HzkJowgb9PrlbatRlgFYqk1IucsL2s=
 github.com/crypto-org-chain/cosmos-sdk/x/tx v0.0.0-20240626040048-36295f051595/go.mod h1:RTiTs4hkXG6IvYGknvB8p79YgjYJdcbzLUOGJChsPnY=
-github.com/crypto-org-chain/ethermint v0.6.1-0.20240702125417-e5b222ffaf90 h1:ShLhFPxmerMFSxoFBKUZuYr8C8iaqBRiMpMaQojFCmU=
-github.com/crypto-org-chain/ethermint v0.6.1-0.20240702125417-e5b222ffaf90/go.mod h1:z5zfkmH6XonIpRzMzFoZU+QSBkXSe5GdRvRWiK9fiA8=
 github.com/crypto-org-chain/go-block-stm v0.0.0-20240408011717-9f11af197bde h1:sQIHTJfVt5VTrF7po9eZiFkZiPjlHbFvnXtGCOoBjNM=
 github.com/crypto-org-chain/go-block-stm v0.0.0-20240408011717-9f11af197bde/go.mod h1:iwQTX9xMX8NV9k3o2BiWXA0SswpsZrDk5q3gA7nWYiE=
 github.com/crypto-org-chain/go-ethereum v1.10.20-0.20240425065928-ebb09502e7a7 h1:V43F3JFcqG4MUThf9W/DytnPblpR6CcaLBw2Wx6zTgE=
@@ -1162,6 +1158,10 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
+github.com/yihuang/cosmos-sdk v0.43.0-beta1.0.20240712031138-3ff3dff0ad1d h1:nRWDIXU5hAWSd+W+4wPEjlAygBD1ynvdbMieQo3mfyA=
+github.com/yihuang/cosmos-sdk v0.43.0-beta1.0.20240712031138-3ff3dff0ad1d/go.mod h1:bIUzWfqXnCF2WTFb2uN+FjzMIG3BsOk+P2QmvMtm4ic=
+github.com/yihuang/ethermint v0.6.1-0.20240712032427-2cbbf8551191 h1:B8DIrcP+NoPX+ELeTET2ECHPO0cGwirPg7vVw3MXtl4=
+github.com/yihuang/ethermint v0.6.1-0.20240712032427-2cbbf8551191/go.mod h1:zwtLGjognR4at43R/SI95nkY/AZcFrNUitvPONQV508=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -428,6 +428,8 @@ github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20240626040048-36295f051595 
 github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20240626040048-36295f051595/go.mod h1:gjE3DZe4t/+VeIk6CmrouyqiuDbZ7QOVDDq3nLqBTpg=
 github.com/crypto-org-chain/cosmos-sdk/x/tx v0.0.0-20240626040048-36295f051595 h1:MPKv1EzM16dx+HzkJowgb9PrlbatRlgFYqk1IucsL2s=
 github.com/crypto-org-chain/cosmos-sdk/x/tx v0.0.0-20240626040048-36295f051595/go.mod h1:RTiTs4hkXG6IvYGknvB8p79YgjYJdcbzLUOGJChsPnY=
+github.com/crypto-org-chain/ethermint v0.6.1-0.20240715061533-9c959a26e04f h1:/27Pg87DNRG0xzctT8XcEANKF0OksPgFJtcQSRs5O0E=
+github.com/crypto-org-chain/ethermint v0.6.1-0.20240715061533-9c959a26e04f/go.mod h1:Xap56y3WoiP7DyNammmB6N7P+Y83QQd6363RHGuaYV0=
 github.com/crypto-org-chain/go-block-stm v0.0.0-20240408011717-9f11af197bde h1:sQIHTJfVt5VTrF7po9eZiFkZiPjlHbFvnXtGCOoBjNM=
 github.com/crypto-org-chain/go-block-stm v0.0.0-20240408011717-9f11af197bde/go.mod h1:iwQTX9xMX8NV9k3o2BiWXA0SswpsZrDk5q3gA7nWYiE=
 github.com/crypto-org-chain/go-ethereum v1.10.20-0.20240425065928-ebb09502e7a7 h1:V43F3JFcqG4MUThf9W/DytnPblpR6CcaLBw2Wx6zTgE=
@@ -1160,8 +1162,6 @@ github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRT
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yihuang/cosmos-sdk v0.43.0-beta1.0.20240712031138-3ff3dff0ad1d h1:nRWDIXU5hAWSd+W+4wPEjlAygBD1ynvdbMieQo3mfyA=
 github.com/yihuang/cosmos-sdk v0.43.0-beta1.0.20240712031138-3ff3dff0ad1d/go.mod h1:bIUzWfqXnCF2WTFb2uN+FjzMIG3BsOk+P2QmvMtm4ic=
-github.com/yihuang/ethermint v0.6.1-0.20240712032427-2cbbf8551191 h1:B8DIrcP+NoPX+ELeTET2ECHPO0cGwirPg7vVw3MXtl4=
-github.com/yihuang/ethermint v0.6.1-0.20240712032427-2cbbf8551191/go.mod h1:zwtLGjognR4at43R/SI95nkY/AZcFrNUitvPONQV508=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -170,9 +170,9 @@ schema = 3
     version = "v1.0.0-beta.5"
     hash = "sha256-Fy/PbsOsd6iq0Njy3DVWK6HqWsogI+MkE8QslHGWyVg="
   [mod."github.com/cosmos/cosmos-sdk"]
-    version = "v0.50.6-0.20240715031529-5a1594f17924"
-    hash = "sha256-1oX4RDHti4eGTkHIdqUZfCYUXpw5Ao7oBZDfZclF1Mk="
-    replaced = "github.com/crypto-org-chain/cosmos-sdk"
+    version = "v0.46.0-beta2.0.20240715072401-d2de62e1575e"
+    hash = "sha256-B1+kqJ72qrA34TCfxoazHTZwI2jI6VZn1WnFpyBIu18="
+    replaced = "github.com/mmsqe/cosmos-sdk"
   [mod."github.com/cosmos/go-bip39"]
     version = "v1.0.0"
     hash = "sha256-Qm2aC2vaS8tjtMUbHmlBSagOSqbduEEDwc51qvQaBmA="

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -170,9 +170,9 @@ schema = 3
     version = "v1.0.0-beta.5"
     hash = "sha256-Fy/PbsOsd6iq0Njy3DVWK6HqWsogI+MkE8QslHGWyVg="
   [mod."github.com/cosmos/cosmos-sdk"]
-    version = "v0.46.0-beta2.0.20240715072401-d2de62e1575e"
-    hash = "sha256-B1+kqJ72qrA34TCfxoazHTZwI2jI6VZn1WnFpyBIu18="
-    replaced = "github.com/mmsqe/cosmos-sdk"
+    version = "v0.50.6-0.20240716063309-c47504d189d4"
+    hash = "sha256-ukD0WZAMJ9hdwzBXzc6a60VOopZ6u+pdf67iq/1Tfa4="
+    replaced = "github.com/crypto-org-chain/cosmos-sdk"
   [mod."github.com/cosmos/go-bip39"]
     version = "v1.0.0"
     hash = "sha256-Qm2aC2vaS8tjtMUbHmlBSagOSqbduEEDwc51qvQaBmA="
@@ -454,9 +454,6 @@ schema = 3
   [mod."github.com/lib/pq"]
     version = "v1.10.7"
     hash = "sha256-YPUv1VBZNFVUjFxQKdYd0Djje6KYYE99Hz6FnTfrmMw="
-  [mod."github.com/libp2p/go-buffer-pool"]
-    version = "v0.1.0"
-    hash = "sha256-wQqGTtRWsfR9n0O/SXHVgECebbnNmHddxJIbG63OJBQ="
   [mod."github.com/linxGnu/grocksdb"]
     version = "v1.9.2"
     hash = "sha256-ThXtaXx6LvRIFW4xLHsMrVWdsN2qobLPA0InLmlADOM="

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -170,9 +170,9 @@ schema = 3
     version = "v1.0.0-beta.5"
     hash = "sha256-Fy/PbsOsd6iq0Njy3DVWK6HqWsogI+MkE8QslHGWyVg="
   [mod."github.com/cosmos/cosmos-sdk"]
-    version = "v0.0.0-20240626040048-36295f051595"
-    hash = "sha256-rwGLcCHeeq74zLoqZ/yCSB6WdHmdwFiz/xRw1SIiBYQ="
-    replaced = "github.com/crypto-org-chain/cosmos-sdk"
+    version = "v0.43.0-beta1.0.20240712031138-3ff3dff0ad1d"
+    hash = "sha256-sr85B4cv/v/VtoH9/u0tV8tq3z96E+pqMmhnmnFnN3g="
+    replaced = "github.com/yihuang/cosmos-sdk"
   [mod."github.com/cosmos/go-bip39"]
     version = "v1.0.0"
     hash = "sha256-Qm2aC2vaS8tjtMUbHmlBSagOSqbduEEDwc51qvQaBmA="
@@ -262,9 +262,9 @@ schema = 3
     hash = "sha256-lE4G5FaRb3MVi9FFVn+WlwsSTOB4SbjmVboKyQ5yB0A="
     replaced = "github.com/crypto-org-chain/go-ethereum"
   [mod."github.com/evmos/ethermint"]
-    version = "v0.6.1-0.20240702125417-e5b222ffaf90"
-    hash = "sha256-nkV3/yK5Eco9B3ifhLa5B0yGnCMjLzCxEdGq/z2rmhA="
-    replaced = "github.com/crypto-org-chain/ethermint"
+    version = "v0.6.1-0.20240712032427-2cbbf8551191"
+    hash = "sha256-F9bjFQ7RaCK1G/dIIu4hrmJaW/Dkpf6ei1oDUjPya/E="
+    replaced = "github.com/yihuang/ethermint"
   [mod."github.com/fatih/color"]
     version = "v1.16.0"
     hash = "sha256-Aq/SM28aPJVzvapllQ64R/DM4aZ5CHPewcm/AUJPyJQ="

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -170,9 +170,9 @@ schema = 3
     version = "v1.0.0-beta.5"
     hash = "sha256-Fy/PbsOsd6iq0Njy3DVWK6HqWsogI+MkE8QslHGWyVg="
   [mod."github.com/cosmos/cosmos-sdk"]
-    version = "v0.43.0-beta1.0.20240712031138-3ff3dff0ad1d"
-    hash = "sha256-sr85B4cv/v/VtoH9/u0tV8tq3z96E+pqMmhnmnFnN3g="
-    replaced = "github.com/yihuang/cosmos-sdk"
+    version = "v0.50.6-0.20240715031529-5a1594f17924"
+    hash = "sha256-1oX4RDHti4eGTkHIdqUZfCYUXpw5Ao7oBZDfZclF1Mk="
+    replaced = "github.com/crypto-org-chain/cosmos-sdk"
   [mod."github.com/cosmos/go-bip39"]
     version = "v1.0.0"
     hash = "sha256-Qm2aC2vaS8tjtMUbHmlBSagOSqbduEEDwc51qvQaBmA="

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -262,9 +262,9 @@ schema = 3
     hash = "sha256-lE4G5FaRb3MVi9FFVn+WlwsSTOB4SbjmVboKyQ5yB0A="
     replaced = "github.com/crypto-org-chain/go-ethereum"
   [mod."github.com/evmos/ethermint"]
-    version = "v0.6.1-0.20240712032427-2cbbf8551191"
-    hash = "sha256-F9bjFQ7RaCK1G/dIIu4hrmJaW/Dkpf6ei1oDUjPya/E="
-    replaced = "github.com/yihuang/ethermint"
+    version = "v0.6.1-0.20240715061533-9c959a26e04f"
+    hash = "sha256-REZAPHulyi4veAg3ij721eSrF7yjopGkc6NPfTMaow8="
+    replaced = "github.com/crypto-org-chain/ethermint"
   [mod."github.com/fatih/color"]
     version = "v1.16.0"
     hash = "sha256-Aq/SM28aPJVzvapllQ64R/DM4aZ5CHPewcm/AUJPyJQ="


### PR DESCRIPTION
## Benchmark Results

### 1 unique account (Worst Case)

```
goos: darwin
goarch: arm64
pkg: github.com/crypto-org-chain/cronos/v2/app
                                │ /tmp/before  │             /tmp/after             │
                                │    sec/op    │   sec/op     vs base               │
ERC20Transfer/memdb-16            626.5m ±  2%   609.6m ± 2%   -2.70% (p=0.002 n=6)
ERC20Transfer/leveldb-16          628.2m ±  2%   618.0m ± 2%   -1.63% (p=0.041 n=6)
ERC20Transfer/memiavl-16          635.6m ±  2%   625.1m ± 4%        ~ (p=0.065 n=6)
ERC20Transfer/memiavl-stm-1-16    781.4m ±  1%   777.7m ± 2%        ~ (p=0.485 n=6)
ERC20Transfer/memiavl-stm-8-16    884.2m ±  1%   730.2m ± 1%  -17.41% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-16-16    1.584 ±  9%    1.553 ± 6%        ~ (p=0.394 n=6)
ERC20Transfer/memiavl-stm-32-16    4.729 ± 11%    4.731 ± 4%        ~ (p=0.937 n=6)
geomean                            1.038         997.5m        -3.87%

                                │  /tmp/before  │             /tmp/after              │
                                │     B/op      │     B/op      vs base               │
ERC20Transfer/memdb-16            366.1Mi ±  0%   366.7Mi ± 0%   +0.16% (p=0.002 n=6)
ERC20Transfer/leveldb-16          368.5Mi ±  0%   369.1Mi ± 0%   +0.17% (p=0.002 n=6)
ERC20Transfer/memiavl-16          364.3Mi ±  0%   364.9Mi ± 0%   +0.17% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-1-16    500.4Mi ±  0%   502.7Mi ± 0%   +0.46% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-8-16    1.911Gi ±  0%   2.723Gi ± 1%  +42.49% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-16-16   4.224Gi ± 11%   6.844Gi ± 3%  +62.01% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-32-16   12.45Gi ± 10%   20.14Gi ± 4%  +61.75% (p=0.002 n=6)
geomean                           1.123Gi         1.357Gi       +20.87%

                                │ /tmp/before  │             /tmp/after              │
                                │  allocs/op   │  allocs/op    vs base               │
ERC20Transfer/memdb-16            4.745M ±  0%    4.745M ± 0%        ~ (p=0.310 n=6)
ERC20Transfer/leveldb-16          4.745M ±  0%    4.745M ± 0%        ~ (p=0.240 n=6)
ERC20Transfer/memiavl-16          4.707M ±  0%    4.707M ± 0%        ~ (p=0.240 n=6)
ERC20Transfer/memiavl-stm-1-16    6.226M ±  0%    6.241M ± 0%   +0.24% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-8-16    32.38M ±  0%    47.07M ± 1%  +45.40% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-16-16   74.71M ± 11%   122.43M ± 3%  +63.87% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-32-16   226.2M ± 10%    365.6M ± 4%  +61.67% (p=0.002 n=6)
geomean                           16.69M          20.24M       +21.29%
```

### 100 unique accounts

```
goos: darwin
goarch: arm64
pkg: github.com/crypto-org-chain/cronos/v2/app
                                │ /tmp/before │             /tmp/after             │
                                │   sec/op    │    sec/op     vs base              │
ERC20Transfer/memdb-16            640.0m ± 3%   624.7m ±  1%       ~ (p=0.093 n=6)
ERC20Transfer/leveldb-16          645.4m ± 2%   622.4m ±  1%  -3.57% (p=0.002 n=6)
ERC20Transfer/memiavl-16          650.5m ± 2%   629.4m ±  2%  -3.25% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-1-16    774.0m ± 1%   751.1m ±  1%  -2.95% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-8-16    137.7m ± 1%   136.7m ±  5%       ~ (p=0.485 n=6)
ERC20Transfer/memiavl-stm-16-16   126.4m ± 2%   122.8m ± 10%       ~ (p=0.093 n=6)
ERC20Transfer/memiavl-stm-32-16   167.1m ± 6%   160.8m ±  3%  -3.82% (p=0.041 n=6)
geomean                           346.9m        337.2m        -2.80%

                                │ /tmp/before  │             /tmp/after             │
                                │     B/op     │     B/op      vs base              │
ERC20Transfer/memdb-16            368.5Mi ± 0%   369.1Mi ± 0%  +0.17% (p=0.002 n=6)
ERC20Transfer/leveldb-16          371.0Mi ± 0%   371.7Mi ± 0%  +0.17% (p=0.002 n=6)
ERC20Transfer/memiavl-16          364.8Mi ± 0%   365.4Mi ± 0%  +0.17% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-1-16    457.9Mi ± 0%   460.2Mi ± 0%  +0.50% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-8-16    469.3Mi ± 0%   471.1Mi ± 0%  +0.38% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-16-16   486.3Mi ± 0%   486.4Mi ± 0%       ~ (p=0.699 n=6)
ERC20Transfer/memiavl-stm-32-16   512.4Mi ± 1%   514.7Mi ± 0%  +0.44% (p=0.009 n=6)
geomean                           428.9Mi        430.1Mi       +0.26%

                                │ /tmp/before │            /tmp/after             │
                                │  allocs/op  │  allocs/op   vs base              │
ERC20Transfer/memdb-16            4.773M ± 0%   4.773M ± 0%       ~ (p=1.000 n=6)
ERC20Transfer/leveldb-16          4.771M ± 0%   4.771M ± 0%       ~ (p=0.937 n=6)
ERC20Transfer/memiavl-16          4.709M ± 0%   4.709M ± 0%       ~ (p=0.485 n=6)
ERC20Transfer/memiavl-stm-1-16    5.848M ± 0%   5.863M ± 0%  +0.26% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-8-16    6.007M ± 0%   6.015M ± 0%  +0.13% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-16-16   6.252M ± 0%   6.235M ± 0%       ~ (p=0.093 n=6)
ERC20Transfer/memiavl-stm-32-16   6.727M ± 1%   6.741M ± 0%       ~ (p=0.132 n=6)
geomean                           5.531M        5.534M       +0.05%
```

### 10 unique accounts

```
benchstat /tmp/before /tmp/after                                                                                                                                                                     ~/src/cronos
goos: darwin
goarch: arm64
pkg: github.com/crypto-org-chain/cronos/v2/app
                                │ /tmp/before  │             /tmp/after              │
                                │    sec/op    │    sec/op     vs base               │
ERC20Transfer/memdb-16            635.6m ±  3%   643.2m ±  1%        ~ (p=0.132 n=6)
ERC20Transfer/leveldb-16          634.1m ±  1%   639.0m ±  1%   +0.77% (p=0.015 n=6)
ERC20Transfer/memiavl-16          637.5m ±  1%   641.8m ±  1%   +0.67% (p=0.041 n=6)
ERC20Transfer/memiavl-stm-1-16    772.6m ±  1%   775.4m ±  1%        ~ (p=0.240 n=6)
ERC20Transfer/memiavl-stm-8-16    176.2m ±  0%   160.3m ±  1%   -9.04% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-16-16   201.4m ± 16%   173.7m ± 16%  -13.79% (p=0.009 n=6)
ERC20Transfer/memiavl-stm-32-16   382.3m ± 11%   375.5m ±  9%        ~ (p=0.589 n=6)
geomean                           429.4m         415.5m         -3.25%

                                │ /tmp/before  │             /tmp/after              │
                                │     B/op     │     B/op      vs base               │
ERC20Transfer/memdb-16            366.3Mi ± 0%   366.9Mi ± 0%   +0.17% (p=0.002 n=6)
ERC20Transfer/leveldb-16          368.7Mi ± 0%   369.3Mi ± 0%   +0.16% (p=0.002 n=6)
ERC20Transfer/memiavl-16          364.3Mi ± 0%   364.9Mi ± 0%   +0.17% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-1-16    478.2Mi ± 0%   480.5Mi ± 0%   +0.48% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-8-16    554.5Mi ± 0%   553.6Mi ± 0%   -0.16% (p=0.041 n=6)
ERC20Transfer/memiavl-stm-16-16   697.4Mi ± 1%   711.8Mi ± 3%   +2.07% (p=0.004 n=6)
ERC20Transfer/memiavl-stm-32-16   1.063Gi ± 3%   1.333Gi ± 8%  +25.37% (p=0.002 n=6)
geomean                           517.2Mi        536.4Mi        +3.71%

                                │ /tmp/before │             /tmp/after              │
                                │  allocs/op  │  allocs/op    vs base               │
ERC20Transfer/memdb-16            4.747M ± 0%    4.747M ± 0%        ~ (p=0.937 n=6)
ERC20Transfer/leveldb-16          4.747M ± 0%    4.747M ± 0%        ~ (p=0.589 n=6)
ERC20Transfer/memiavl-16          4.706M ± 0%    4.706M ± 0%        ~ (p=0.818 n=6)
ERC20Transfer/memiavl-stm-1-16    6.016M ± 0%    6.031M ± 0%   +0.25% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-8-16    7.288M ± 0%    7.211M ± 1%   -1.06% (p=0.002 n=6)
ERC20Transfer/memiavl-stm-16-16   9.827M ± 2%   10.037M ± 4%   +2.14% (p=0.009 n=6)
ERC20Transfer/memiavl-stm-32-16   16.84M ± 4%    21.74M ± 9%  +29.10% (p=0.002 n=6)
geomean                           6.932M         7.203M        +3.91%
```

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Enhanced performance by caching signature verification results for recurring transactions.

- **Dependency Updates**
  - Updated `cosmos-sdk` to version `v0.50.6`.
  - Updated `ethermint` to version `v0.6.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->