### PR TITLE
Problem: no option to exit early for fullnodes

### DIFF
--- a/testground/benchmark/compositions/docker-compose.jsonnet
+++ b/testground/benchmark/compositions/docker-compose.jsonnet
@@ -1,7 +1,7 @@
 std.manifestYamlDoc({
   services: {
     ['testplan-' + i]: {
-      image: 'cronos-testground:latest',
+      image: 'cronos-testground:d0q500phfw58nm6bygpxr2w5g67mm9fq',
       command: 'stateless-testcase run',
       container_name: 'testplan-' + i,
       volumes: [
@@ -11,6 +11,6 @@ std.manifestYamlDoc({
         JOB_COMPLETION_INDEX: i,
       },
     }
-    for i in std.range(0, 9)
+    for i in std.range(0, 7)
   },
 })


### PR DESCRIPTION
add exit-on-finish to allow early quit after send txs are done

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line option `--exit-on-finish` for enhanced control over process completion behavior.
  
- **Improvements**
	- Updated Docker image tag to a specific version for improved stability and predictability in deployments.
	- Reduced the number of service instances from 10 to 8, optimizing resource allocation and testing strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->