### PR TITLE
Problem: can't read timestamp in versiondb iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Improvements
 
 * [#1684](https://github.com/crypto-org-chain/cronos/pull/1684) versiondb NewKVStore accept string as store name.
+* [#]() Add Timestamp api to versiondb iterator.
 
 *Nov 6, 2024*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Improvements
 
 * [#1684](https://github.com/crypto-org-chain/cronos/pull/1684) versiondb NewKVStore accept string as store name.
-* [#]() Add Timestamp api to versiondb iterator.
+* [#1688](https://github.com/crypto-org-chain/cronos/pull/1688) Add Timestamp api to versiondb iterator.
 
 *Nov 6, 2024*
 

--- a/versiondb/tsrocksdb/iterator.go
+++ b/versiondb/tsrocksdb/iterator.go
@@ -3,7 +3,7 @@ package tsrocksdb
 import (
 	"bytes"
 
-	"cosmossdk.io/store/types"
+	"github.com/crypto-org-chain/cronos/versiondb"
 	"github.com/linxGnu/grocksdb"
 )
 
@@ -14,7 +14,7 @@ type rocksDBIterator struct {
 	isInvalid          bool
 }
 
-var _ types.Iterator = (*rocksDBIterator)(nil)
+var _ versiondb.Iterator = (*rocksDBIterator)(nil)
 
 func newRocksDBIterator(source *grocksdb.Iterator, prefix, start, end []byte, isReverse bool) *rocksDBIterator {
 	if isReverse {
@@ -92,6 +92,12 @@ func (itr *rocksDBIterator) Valid() bool {
 
 	// It's valid.
 	return true
+}
+
+// Timestamp implements Iterator.
+func (itr *rocksDBIterator) Timestamp() []byte {
+	itr.assertIsValid()
+	return moveSliceToBytes(itr.source.Timestamp())
 }
 
 // Key implements Iterator.

--- a/versiondb/tsrocksdb/store.go
+++ b/versiondb/tsrocksdb/store.go
@@ -127,7 +127,7 @@ func (s Store) GetLatestVersion() (int64, error) {
 }
 
 // IteratorAtVersion implements VersionStore interface
-func (s Store) IteratorAtVersion(storeKey string, start, end []byte, version *int64) (types.Iterator, error) {
+func (s Store) IteratorAtVersion(storeKey string, start, end []byte, version *int64) (versiondb.Iterator, error) {
 	if (start != nil && len(start) == 0) || (end != nil && len(end) == 0) {
 		return nil, errKeyEmpty
 	}
@@ -140,7 +140,7 @@ func (s Store) IteratorAtVersion(storeKey string, start, end []byte, version *in
 }
 
 // ReverseIteratorAtVersion implements VersionStore interface
-func (s Store) ReverseIteratorAtVersion(storeKey string, start, end []byte, version *int64) (types.Iterator, error) {
+func (s Store) ReverseIteratorAtVersion(storeKey string, start, end []byte, version *int64) (versiondb.Iterator, error) {
 	if (start != nil && len(start) == 0) || (end != nil && len(end) == 0) {
 		return nil, errKeyEmpty
 	}

--- a/versiondb/types.go
+++ b/versiondb/types.go
@@ -4,14 +4,20 @@ import (
 	"cosmossdk.io/store/types"
 )
 
+type Iterator interface {
+	types.Iterator
+
+	Timestamp() []byte
+}
+
 // VersionStore is a versioned storage of a flat key-value pairs.
 // it don't need to support merkle proof, so could be implemented in a much more efficient way.
 // `nil` version means the latest version.
 type VersionStore interface {
 	GetAtVersion(storeKey string, key []byte, version *int64) ([]byte, error)
 	HasAtVersion(storeKey string, key []byte, version *int64) (bool, error)
-	IteratorAtVersion(storeKey string, start, end []byte, version *int64) (types.Iterator, error)
-	ReverseIteratorAtVersion(storeKey string, start, end []byte, version *int64) (types.Iterator, error)
+	IteratorAtVersion(storeKey string, start, end []byte, version *int64) (Iterator, error)
+	ReverseIteratorAtVersion(storeKey string, start, end []byte, version *int64) (Iterator, error)
 	GetLatestVersion() (int64, error)
 
 	// Persist the change set of a block,


### PR DESCRIPTION
Solution:
- add timestamp api to versiondb iterator, at least useful in debugging.

👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Timestamp API for improved iteration capabilities in the versioned storage system.
	- Added support for registering payees and counterparty payees in the relayer precompile.

- **Bug Fixes**
	- Resolved issues related to insufficient balance and node shutdown signals.
	- Updated dependencies, including a pruning fix for the `iavl` dependency.

- **Improvements**
	- Enhanced transaction generation and benchmark support.
	- Updated methods to ensure type consistency across interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->