### PR TITLE
chore: fix some comments

### DIFF
--- a/docs/gravity-bridge/dev-setup-guide.md
+++ b/docs/gravity-bridge/dev-setup-guide.md
@@ -118,7 +118,7 @@ message DelegateKeysSignMsg {
 }
 ```
 
-Use your favorite protobuf library to encode the message, and use your favorite web3 library to do the messge signing,
+Use your favorite protobuf library to encode the message, and use your favorite web3 library to do the message signing,
 for example, this is how it could be done in python:
 
 ```python

--- a/memiavl/db.go
+++ b/memiavl/db.go
@@ -488,7 +488,7 @@ func (db *DB) checkBackgroundSnapshotRewrite() error {
 	return nil
 }
 
-// pruneSnapshot prune the old snapshots
+// pruneSnapshots prune the old snapshots
 func (db *DB) pruneSnapshots() {
 	// wait until last prune finish
 	db.pruneSnapshotLock.Lock()

--- a/memiavl/snapshot.go
+++ b/memiavl/snapshot.go
@@ -67,7 +67,7 @@ func OpenSnapshot(snapshotDir string) (snapshot *Snapshot, err error) {
 		return nil, err
 	}
 	if len(bz) != SizeMetadata {
-		return nil, fmt.Errorf("wrong metadata file size, expcted: %d, found: %d", SizeMetadata, len(bz))
+		return nil, fmt.Errorf("wrong metadata file size, expected: %d, found: %d", SizeMetadata, len(bz))
 	}
 
 	magic := binary.LittleEndian.Uint32(bz)

--- a/versiondb/extsort/sort.go
+++ b/versiondb/extsort/sort.go
@@ -1,4 +1,4 @@
-// Package extsort implements external sorting algorithm, it has several differnet design choices compared with alternatives like https://github.com/lanrat/extsort:
+// Package extsort implements external sorting algorithm, it has several different design choices compared with alternatives like https://github.com/lanrat/extsort:
 //   - apply efficient compressions(delta encoding + snappy) to the chunk files to reduce IO cost,
 //     since the items are sorted, delta encoding should be effective to it, and snappy is pretty efficient.
 //   - chunks are stored in separate temporary files, so the chunk sorting and saving can run in parallel (eats more ram though).
@@ -25,7 +25,7 @@ type Options struct {
 	DeltaEncoding bool
 	// if apply snappy compression to the items in sorted chunk
 	SnappyCompression bool
-	// Maxiumum uncompressed size of the sorted chunk
+	// Maximum uncompressed size of the sorted chunk
 	MaxChunkSize int64
 	// function that compares two items
 	LesserFunc LesserFunc


### PR DESCRIPTION


 fix some comments




# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected typographical errors in user and developer documentation for improved clarity.
- **Style**
  - Fixed typos in code comments and error messages to enhance readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->