### PR TITLE
fix: Add default value of CancunTime and PragueTime in chain config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@
 
 
 ### Improvements
+
 * [#1841](https://github.com/crypto-org-chain/cronos/pull/1841) Ci: use `golangci-lint run --fix`.
 * [#1779](https://github.com/crypto-org-chain/cronos/pull/1779) Upgrade rocksdb to `v9.11.2`.
 * [#1824](https://github.com/crypto-org-chain/cronos/pull/1824) Rework on github actions.
 * [#1826](https://github.com/crypto-org-chain/cronos/pull/1826) Update linter and tidy up code.
 * [#1807](https://github.com/crypto-org-chain/cronos/pull/1807) Update go-ethereum version to [v1.15.11](https://github.com/ethereum/go-ethereum/releases/tag/v1.15.11).
 * [#1840](https://github.com/crypto-org-chain/cronos/pull/1840) Tx replacement support.
+* [#1850](https://github.com/crypto-org-chain/cronos/pull/1850) Add default value of CancunTime and PragueTime in chain config.
 
 *Jun 20, 2025*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [#1826](https://github.com/crypto-org-chain/cronos/pull/1826) Update linter and tidy up code.
 * [#1807](https://github.com/crypto-org-chain/cronos/pull/1807) Update go-ethereum version to [v1.15.11](https://github.com/ethereum/go-ethereum/releases/tag/v1.15.11).
 * [#1840](https://github.com/crypto-org-chain/cronos/pull/1840) Tx replacement support.
-* [#1850](https://github.com/crypto-org-chain/cronos/pull/1850) Add default value of CancunTime and PragueTime in chain config.
+* [#1851](https://github.com/crypto-org-chain/cronos/pull/1850) Add default value of CancunTime and PragueTime in chain config.
 
 *Jun 20, 2025*
 

--- a/go.mod
+++ b/go.mod
@@ -305,7 +305,7 @@ replace (
 	// release/v1.15
 	github.com/ethereum/go-ethereum => github.com/crypto-org-chain/go-ethereum v1.10.20-0.20250815065500-a4fbafcae0dd
 	// develop
-	github.com/evmos/ethermint => github.com/crypto-org-chain/ethermint v0.6.1-0.20250819081101-9a03795ec96b
+	github.com/evmos/ethermint => github.com/crypto-org-chain/ethermint v0.6.1-0.20250820110050-d940a537fb81
 	// Fix upstream GHSA-h395-qcrw-5vmq and GHSA-3vp4-m3rf-835h vulnerabilities.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -910,8 +910,8 @@ github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20241217090828-cfbca9fe8254 
 github.com/crypto-org-chain/cosmos-sdk/store v0.0.0-20241217090828-cfbca9fe8254/go.mod h1:8DwVTz83/2PSI366FERGbWSH7hL6sB7HbYp8bqksNwM=
 github.com/crypto-org-chain/cosmos-sdk/x/tx v0.0.0-20241217090828-cfbca9fe8254 h1:JzLOFRiKsDtLJt5h0M0jkEIPDKvFFyja7VEp7gG6O9U=
 github.com/crypto-org-chain/cosmos-sdk/x/tx v0.0.0-20241217090828-cfbca9fe8254/go.mod h1:V6DImnwJMTq5qFjeGWpXNiT/fjgE4HtmclRmTqRVM3w=
-github.com/crypto-org-chain/ethermint v0.6.1-0.20250819081101-9a03795ec96b h1:Tm6Hm2id0PRMc8LNQduNY3bA6nvEz/qXoAyTpnEHCHA=
-github.com/crypto-org-chain/ethermint v0.6.1-0.20250819081101-9a03795ec96b/go.mod h1:pilxRzYqGqlhVBDXcBYfDbFy6vkiqxwc8zHDPYXLnOQ=
+github.com/crypto-org-chain/ethermint v0.6.1-0.20250820110050-d940a537fb81 h1:WCfAxy31LBHVwcAlJfU4XEGlUppoeJSn+fRcdIQfiuA=
+github.com/crypto-org-chain/ethermint v0.6.1-0.20250820110050-d940a537fb81/go.mod h1:pilxRzYqGqlhVBDXcBYfDbFy6vkiqxwc8zHDPYXLnOQ=
 github.com/crypto-org-chain/go-block-stm v0.0.0-20241213061541-7afe924fb4a6 h1:6KPEi8dWkDSBddQb4NAvEXmNnTXymF3yVeTaT4Hz1iU=
 github.com/crypto-org-chain/go-block-stm v0.0.0-20241213061541-7afe924fb4a6/go.mod h1:iwQTX9xMX8NV9k3o2BiWXA0SswpsZrDk5q3gA7nWYiE=
 github.com/crypto-org-chain/go-ethereum v1.10.20-0.20250815065500-a4fbafcae0dd h1:ebSnzvM9yKVGFjvoGly7LFQQCS2HuOWMCvQyByJ52Gs=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -314,8 +314,8 @@ schema = 3
     version = "v0.2.2"
     hash = "sha256-0MLfSJKdeK3Z7tWAXTdzwB4091dmyxIX38S5SKH5QAw="
   [mod."github.com/evmos/ethermint"]
-    version = "v0.6.1-0.20250819081101-9a03795ec96b"
-    hash = "sha256-AbomdzYu7acbuQooMZwqe8vh08Q2jBYtRAMaZF3Yg+4="
+    version = "v0.6.1-0.20250820110050-d940a537fb81"
+    hash = "sha256-IiOutLdexw9kqigNKbQYqRvIuMj9V7HD2LLDubJ7XJQ="
     replaced = "github.com/crypto-org-chain/ethermint"
   [mod."github.com/fatih/color"]
     version = "v1.17.0"

--- a/integration_tests/contracts/contracts/TestSuicide.sol
+++ b/integration_tests/contracts/contracts/TestSuicide.sol
@@ -5,6 +5,8 @@ contract Destroyee {
     function destroy() public {
         selfdestruct(payable(msg.sender));
     }
+
+    receive() external payable {}
 }
 
 contract Destroyer {
@@ -17,4 +19,6 @@ contract Destroyer {
         }
         require(_size > 0);
     }
+
+    receive() external payable {}
 }

--- a/integration_tests/test_basic.py
+++ b/integration_tests/test_basic.py
@@ -25,11 +25,13 @@ from .utils import (
     contract_path,
     deploy_contract,
     derive_new_account,
+    fund_acc,
     get_account_nonce,
     get_expedited_params,
     get_receipts_by_block,
     get_sync_info,
     modify_command_in_supervisor_config,
+    remove_cancun_prague_params,
     replace_transaction,
     send_transaction,
     send_txs,
@@ -669,11 +671,38 @@ def test_message_call(cronos):
     assert len(receipt.logs) == iterations
 
 
-def test_suicide(cluster):
+def test_suicide_pre_cancun(cronos):
     """
     test compliance of contract suicide
     - within the tx, after contract suicide, the code is still available.
     - after the tx, the code is not available.
+    """
+    remove_cancun_prague_params(cronos)
+    w3 = cronos.w3
+    destroyee = deploy_contract(
+        w3,
+        contract_path("Destroyee", "TestSuicide.sol"),
+    )
+    destroyer = deploy_contract(
+        w3,
+        contract_path("Destroyer", "TestSuicide.sol"),
+    )
+    assert len(w3.eth.get_code(destroyee.address)) > 0
+    assert len(w3.eth.get_code(destroyer.address)) > 0
+
+    tx = destroyer.functions.check_codesize_after_suicide(
+        destroyee.address
+    ).build_transaction()
+    receipt = send_transaction(w3, tx)
+    assert receipt.status == 1
+
+    assert len(w3.eth.get_code(destroyee.address)) == 0
+
+
+def test_suicide_post_cancun(cluster):
+    """
+    after EIP-6780, SELFDESTRUCT will recover all funds to the target
+    but not delete the account, except when called in the same transaction as creation
     """
     w3 = cluster.w3
     destroyee = deploy_contract(
@@ -684,6 +713,11 @@ def test_suicide(cluster):
         w3,
         contract_path("Destroyer", "TestSuicide.sol"),
     )
+
+    balance_wanted = 1000000000000000000
+    fund_acc(w3, destroyee, balance_wanted)
+    assert w3.eth.get_balance(destroyee.address) == balance_wanted
+    assert w3.eth.get_balance(destroyer.address) == 0
 
     old_code_destroyee = w3.eth.get_code(destroyee.address)
     old_code_destroyer = w3.eth.get_code(destroyer.address)
@@ -696,9 +730,9 @@ def test_suicide(cluster):
     receipt = send_transaction(w3, tx)
     assert receipt.status == 1
 
-    # per EIP-6780, SELFDESTRUCT will recover all funds to the target
-    # but not delete the account, except when called in the same transaction as creation
     assert w3.eth.get_code(destroyee.address) == old_code_destroyee
+    assert w3.eth.get_balance(destroyee.address) == 0
+    assert w3.eth.get_balance(destroyer.address) == balance_wanted
 
 
 def test_batch_tx(cronos):

--- a/integration_tests/test_basic.py
+++ b/integration_tests/test_basic.py
@@ -684,8 +684,11 @@ def test_suicide(cluster):
         w3,
         contract_path("Destroyer", "TestSuicide.sol"),
     )
-    assert len(w3.eth.get_code(destroyee.address)) > 0
-    assert len(w3.eth.get_code(destroyer.address)) > 0
+
+    old_code_destroyee = w3.eth.get_code(destroyee.address)
+    old_code_destroyer = w3.eth.get_code(destroyer.address)
+    assert len(old_code_destroyee) > 0
+    assert len(old_code_destroyer) > 0
 
     tx = destroyer.functions.check_codesize_after_suicide(
         destroyee.address
@@ -693,7 +696,9 @@ def test_suicide(cluster):
     receipt = send_transaction(w3, tx)
     assert receipt.status == 1
 
-    assert len(w3.eth.get_code(destroyee.address)) == 0
+    # per EIP-6780, SELFDESTRUCT will recover all funds to the target
+    # but not delete the account, except when called in the same transaction as creation
+    assert w3.eth.get_code(destroyee.address) == old_code_destroyee
 
 
 def test_batch_tx(cronos):

--- a/integration_tests/test_gov_update_params.py
+++ b/integration_tests/test_gov_update_params.py
@@ -17,6 +17,8 @@ def test_evm_update_param(cronos, tmp_path):
     p = cli.query_params("evm")
     del p["chain_config"]["merge_netsplit_block"]
     del p["chain_config"]["shanghai_time"]
+    del p["chain_config"]["cancun_time"]
+    del p["chain_config"]["prague_time"]
     authority = module_address("gov")
     msg = "/ethermint.evm.v1.MsgUpdateParams"
     submit_gov_proposal(
@@ -33,6 +35,8 @@ def test_evm_update_param(cronos, tmp_path):
     p = cli.query_params("evm")
     assert not p["chain_config"]["merge_netsplit_block"]
     assert not p["chain_config"]["shanghai_time"]
+    assert not p["chain_config"]["cancun_time"]
+    assert not p["chain_config"]["prague_time"]
     invalid_msg = "invalid opcode: PUSH0"
     with pytest.raises(ValueError) as e_info:
         contract.caller.randomTokenId()

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -857,11 +857,12 @@ def fund_acc(w3, acc, fund=3000000000000000000):
 
 
 def remove_cancun_prague_params(cronos):
+    from .cosmoscli import module_address as cosmos_module_address
     cli = cronos.cosmos_cli()
     p = cli.query_params("evm")
     del p["chain_config"]["cancun_time"]
     del p["chain_config"]["prague_time"]
-    authority = module_address("gov")
+    authority = cosmos_module_address("gov")
     msg = "/ethermint.evm.v1.MsgUpdateParams"
     submit_gov_proposal(
         cronos,

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -858,6 +858,7 @@ def fund_acc(w3, acc, fund=3000000000000000000):
 
 def remove_cancun_prague_params(cronos):
     from .cosmoscli import module_address as cosmos_module_address
+
     cli = cronos.cosmos_cli()
     p = cli.query_params("evm")
     del p["chain_config"]["cancun_time"]

--- a/scripts/geth-genesis.json
+++ b/scripts/geth-genesis.json
@@ -15,8 +15,20 @@
     "yoloV3Block": 0,
     "londonBlock": 0,
     "shanghaiTime": 0,
-    "cancunTime": null,
-    "pragueTime": null,
+    "cancunTime": 0,
+    "pragueTime": 0,
+    "blobSchedule": {
+      "cancun": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      },
+      "prague": {
+        "target": 3,
+        "max": 6,
+        "baseFeeUpdateFraction": 3338477
+      }
+    },
     "terminalTotalDifficulty": 0,
     "clique": {
       "period": 2,


### PR DESCRIPTION
ethermint pr: https://github.com/crypto-org-chain/ethermint/pull/702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated UNRELEASED notes to document default CancunTime and PragueTime and minor formatting cleanup.

* **Chores**
  * Bumped a core dependency snapshot and updated its lock/hash.
  * Set default Cancun/Prague values and added blob scheduling entries in genesis configuration.

* **Tests**
  * Added helpers to fund test accounts and to remove Cancun/Prague params via governance.
  * Expanded integration tests for pre- and post-Cancun SELFDESTRUCT behavior.

* **Contracts (tests)**
  * Added payable receive handlers to test contracts to support new suicide tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->