### PR TITLE
chore: fix ibc tests with chain-main ibc-go-v10

### DIFF
--- a/integration_tests/cosmoscli.py
+++ b/integration_tests/cosmoscli.py
@@ -939,12 +939,12 @@ class CosmosCLI:
             self.raw(
                 "query",
                 "ibc-transfer",
-                "denom-trace",
+                "denom",
                 denom_hash,
                 node=node,
                 output="json",
             )
-        )["denom_trace"]
+        )["denom"]
 
     def export(self, **kwargs):
         return self.raw("export", home=self.data_dir, **kwargs)

--- a/integration_tests/ibc_utils.py
+++ b/integration_tests/ibc_utils.py
@@ -457,7 +457,11 @@ def ibc_multi_transfer(ibc):
             return False
 
     denom_trace = chains[1].ibc_denom_trace(path, ibc.chainmain.node_rpc(0))
-    assert denom_trace == {"path": f"transfer/{channel1}", "base_denom": denom0}
+    print("denom_trace", denom_trace)
+
+    assert denom_trace["base"] == denom0
+    assert denom_trace["trace"] == [{"port_id": "transfer", "channel_id": channel1}]
+
     for i, _ in enumerate(users):
         wait_for_fn("assert balance", lambda: assert_trace_balance(addrs1[i]))
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,15 +1,15 @@
 {
     "chain-main": {
-        "branch": "master",
+        "branch": "jt/ibc-go-v10",
         "description": "Crypto.org Chain⛓: Croeseid Testnet and beyond development",
         "homepage": "https://crypto.org",
-        "owner": "crypto-org-chain",
+        "owner": "JayT106",
         "repo": "chain-main",
-        "rev": "1baff8aed447abcad5c8d2ea4f92d7ae00d8b8b3",
-        "sha256": "01cg1jfg4l2d6g2spxf3c2375zj0siv8wg1lssafv7ry51f3zyqz",
+        "rev": "293428e4d63c0fd10ffda4c07636b0f1401d648b",
+        "sha256": "0zrdjgvgh02281894ap9msc0rmlz3v4sxpqx55hjskyyahm6hf8d",
         "type": "tarball",
-        "url": "https://github.com/crypto-org-chain/chain-main/archive/1baff8aed447abcad5c8d2ea4f92d7ae00d8b8b3.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+        "url": "https://github.com/JayT106/chain-main/archive/refs/tags/ibc-go-v10/chain-main_devel_Darwin_arm64.tar.gz",
+        "url_template": "https://github.com/JayT106/chain-main/archive/refs/tags/ibc-go-v10/chain-main_devel_Darwin_arm64.tar.gz"
     },
     "dapptools": {
         "branch": "master",


### PR DESCRIPTION
Update chain-main resource to support ibc-go-v10,
It's a template fix once ibc-go-v10 has official released in chain-main repo.