### PR TITLE
fix(ibc): update ibc-go dependency for ibc clientstates  query issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#1959](https://github.com/crypto-org-chain/cronos/pull/1959) refactor: replace MsgEthereumTxResponse with EthCallResponse in EVM calls 
 * [#1959](https://github.com/crypto-org-chain/cronos/pull/1959) fix: eip712 legacy signature verify 
 * [#1963](https://github.com/crypto-org-chain/cronos/pull/1963) fix: apply tachyon patch
+* [#2027](https://github.com/crypto-org-chain/cronos/pull/2027) fix(ibc): update ibc-go dependency for ibc clientstates query issue
 
 *Dec 4, 2025*
 

--- a/go.mod
+++ b/go.mod
@@ -297,7 +297,7 @@ replace (
 	// solves bug on pruning "version does not exist"
 	github.com/cosmos/iavl => github.com/cosmos/iavl v1.2.6
 
-	// Temporary fix for client state query issue
+	// TODO: remove temporary fix for client state query issue v10.5.0-cronos
 	github.com/cosmos/ibc-go/v10 => github.com/crypto-org-chain/ibc-go/v10 v10.0.0-20260421013314-1a60e77d1cba
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134

--- a/go.mod
+++ b/go.mod
@@ -296,6 +296,9 @@ replace (
 	github.com/cometbft/cometbft => github.com/crypto-org-chain/cometbft v0.0.0-20260126040959-178ea8502144
 	// solves bug on pruning "version does not exist"
 	github.com/cosmos/iavl => github.com/cosmos/iavl v1.2.6
+
+	// Temporary fix for client state query issue
+	github.com/cosmos/ibc-go/v10 => github.com/jayt106/ibc-go/v10 v10.0.0-20260420161113-f8d610fd4607
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.mod
+++ b/go.mod
@@ -298,7 +298,7 @@ replace (
 	github.com/cosmos/iavl => github.com/cosmos/iavl v1.2.6
 
 	// Temporary fix for client state query issue
-	github.com/cosmos/ibc-go/v10 => github.com/jayt106/ibc-go/v10 v10.0.0-20260420161113-f8d610fd4607
+	github.com/cosmos/ibc-go/v10 => github.com/crypto-org-chain/ibc-go/v10 v10.0.0-20260421013314-1a60e77d1cba
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -921,6 +921,8 @@ github.com/crypto-org-chain/go-block-stm v0.0.0-20241213061541-7afe924fb4a6 h1:6
 github.com/crypto-org-chain/go-block-stm v0.0.0-20241213061541-7afe924fb4a6/go.mod h1:iwQTX9xMX8NV9k3o2BiWXA0SswpsZrDk5q3gA7nWYiE=
 github.com/crypto-org-chain/go-ethereum v1.10.20-0.20250815065500-a4fbafcae0dd h1:ebSnzvM9yKVGFjvoGly7LFQQCS2HuOWMCvQyByJ52Gs=
 github.com/crypto-org-chain/go-ethereum v1.10.20-0.20250815065500-a4fbafcae0dd/go.mod h1:mf8YiHIb0GR4x4TipcvBUPxJLw1mFdmxzoDi11sDRoI=
+github.com/crypto-org-chain/ibc-go/v10 v10.0.0-20260421013314-1a60e77d1cba h1:PuxeIdAml+6GA583E2bIEv9BSFOy4Qj418fKyCNwNoI=
+github.com/crypto-org-chain/ibc-go/v10 v10.0.0-20260421013314-1a60e77d1cba/go.mod h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=
 github.com/danieljoos/wincred v1.2.1 h1:dl9cBrupW8+r5250DYkYxocLeZ1Y4vB1kxgtjxw8GQs=
 github.com/danieljoos/wincred v1.2.1/go.mod h1:uGaFL9fDn3OLTvzCGulzE+SzjEe5NGlh5FdCcyfPwps=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -1346,8 +1348,6 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
-github.com/jayt106/ibc-go/v10 v10.0.0-20260420161113-f8d610fd4607 h1:tKBWgyf//SjkE0kHYJfz+a2c48kkapYxhSvw35b4zks=
-github.com/jayt106/ibc-go/v10 v10.0.0-20260420161113-f8d610fd4607/go.mod h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.9.0 h1:npqHz788dryJiR/l6K/RUQAyh2SwV91+d1dnh4RjO9w=

--- a/go.sum
+++ b/go.sum
@@ -874,8 +874,6 @@ github.com/cosmos/gogoproto v1.7.2 h1:5G25McIraOC0mRFv9TVO139Uh3OklV2hczr13KKVHC
 github.com/cosmos/gogoproto v1.7.2/go.mod h1:8S7w53P1Y1cHwND64o0BnArT6RmdgIvsBuco6uTllsk=
 github.com/cosmos/iavl v1.2.6 h1:Hs3LndJbkIB+rEvToKJFXZvKo6Vy0Ex1SJ54hhtioIs=
 github.com/cosmos/iavl v1.2.6/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
-github.com/cosmos/ibc-go/v10 v10.5.0 h1:NI+cX04fXdu9JfP0V0GYeRi1ENa7PPdq0BYtVYo8Zrs=
-github.com/cosmos/ibc-go/v10 v10.5.0/go.mod h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=
 github.com/cosmos/ics23/go v0.11.0 h1:jk5skjT0TqX5e5QJbEnwXIS2yI2vnmLOgpQPeM5RtnU=
 github.com/cosmos/ics23/go v0.11.0/go.mod h1:A8OjxPE67hHST4Icw94hOxxFEJMBG031xIGF/JHNIY0=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
@@ -1348,6 +1346,8 @@ github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
+github.com/jayt106/ibc-go/v10 v10.0.0-20260420161113-f8d610fd4607 h1:tKBWgyf//SjkE0kHYJfz+a2c48kkapYxhSvw35b4zks=
+github.com/jayt106/ibc-go/v10 v10.0.0-20260420161113-f8d610fd4607/go.mod h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.9.0 h1:npqHz788dryJiR/l6K/RUQAyh2SwV91+d1dnh4RjO9w=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -230,9 +230,9 @@ schema = 3
     hash = "sha256-9kLtVepU5b3m2Sne8pBQNvF9LxM374LEmvuLWeYBfFU="
     replaced = "github.com/cosmos/iavl"
   [mod."github.com/cosmos/ibc-go/v10"]
-    version = "v10.0.0-20260420161113-f8d610fd4607"
-    hash = "sha256-iT7TJZuvZefixNSisBTa8WaboKcOTIPElLYU9OrnoBw="
-    replaced = "github.com/jayt106/ibc-go/v10"
+    version = "v10.0.0-20260421013314-1a60e77d1cba"
+    hash = "sha256-dQhXGGD06hVg5VrqnxnVLAYxJBxmyfgc5mI/3RASq30="
+    replaced = "github.com/crypto-org-chain/ibc-go/v10"
   [mod."github.com/cosmos/ics23/go"]
     version = "v0.11.0"
     hash = "sha256-mgU/pqp4kASmW/bP0z6PzssfjRp7GU9ioyvNlDdGC+E="

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -230,8 +230,9 @@ schema = 3
     hash = "sha256-9kLtVepU5b3m2Sne8pBQNvF9LxM374LEmvuLWeYBfFU="
     replaced = "github.com/cosmos/iavl"
   [mod."github.com/cosmos/ibc-go/v10"]
-    version = "v10.5.0"
-    hash = "sha256-QuonpvZ5slHNVxtk/ohIt6/yRx3Kmth0jXhSluJRbKE="
+    version = "v10.0.0-20260420161113-f8d610fd4607"
+    hash = "sha256-iT7TJZuvZefixNSisBTa8WaboKcOTIPElLYU9OrnoBw="
+    replaced = "github.com/jayt106/ibc-go/v10"
   [mod."github.com/cosmos/ics23/go"]
     version = "v0.11.0"
     hash = "sha256-mgU/pqp4kASmW/bP0z6PzssfjRp7GU9ioyvNlDdGC+E="


### PR DESCRIPTION
Update ibc-go dependency for preventing clientstates query panic

https://github.com/crypto-org-chain/ibc-go/commit/1a60e77d1cbaf1eb2b527d5e19e1d556558b4c85