### PR TITLE
chore(ci): fix dependabot workflows and drain PR backlog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,82 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 5
+  labels:
+  - dependencies
+  groups:
+    gh-actions:
+      patterns:
+      - "*"
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 5
+  labels:
+  - dependencies
+  groups:
+    docker:
+      patterns:
+      - "*"
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+  groups:
+    cosmos-sdk:
+      patterns:
+      - "cosmossdk.io/*"
+      - "github.com/cosmos/*"
+    otel:
+      patterns:
+      - "go.opentelemetry.io/*"
+    gomod-minor-patch:
+      update-types:
+      - minor
+      - patch
+- package-ecosystem: pip
+  directory: "/integration_tests"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 5
+  labels:
+  - dependencies
+  groups:
+    pip-minor-patch:
+      update-types:
+      - minor
+      - patch
+- package-ecosystem: pip
+  directory: "/testground/benchmark"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 5
+  labels:
+  - dependencies
+  groups:
+    pip-minor-patch:
+      update-types:
+      - minor
+      - patch
+- package-ecosystem: npm
+  directory: "/integration_tests/contracts"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 5
+  labels:
+  - dependencies
+  groups:
+    npm-minor-patch:
+      update-types:
+      - minor
+      - patch

--- a/.github/workflows/dependabot-update-all.yml
+++ b/.github/workflows/dependabot-update-all.yml
@@ -1,5 +1,5 @@
 name: Dependabot Update All Go Modules
-on: pull_request
+on: pull_request_target
 
 permissions:
   contents: write
@@ -11,46 +11,53 @@ env:
 jobs:
   update-all:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: >
+      github.actor == 'dependabot[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'dependabot/go_modules/')
     steps:
       - name: Generate Token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v1
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         id: app-token
         with:
           app-id: "${{ secrets.APP_ID }}"
           private-key: "${{ secrets.APP_PRIVATE_KEY }}"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           token: "${{ steps.app-token.outputs.token }}"
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.10"
           check-latest: true
       - name: Extract updated dependency
         id: deps
         run: |
           set -euo pipefail
-          # Example title:
-          # "build(deps): Bump github.com/cosmos/cosmos-sdk from v0.46.0 to v0.47.0-rc1"
-          
-          dep_name=$(grep -oE 'github.com/[^ ]+' <<<"$PR_TITLE" || true)
+          # Parse Dependabot PR titles of the form:
+          #   build(deps): bump <module-path> from <x> to <y>
+          # Grouped PR titles (e.g. "bump the gomod-minor-patch group across 1 directory")
+          # do not match and are handled by falling through to a tidy-only run.
+          dep_name=$(grep -oE 'github.com/[^ ]+' <<<"$PR_TITLE" | head -1 || true)
           dep_version=$(grep -oE 'to v?([0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?)' <<<"$PR_TITLE" | awk '{print $2}' || true)
-          
+
           if [[ -z "$dep_name" || -z "$dep_version" ]]; then
-             echo "❌ Unable to parse dependency from PR title: $PR_TITLE" >&2
-             exit 1
+            echo "Grouped or unparseable PR title; skipping single-dep update."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "name=$dep_name"
+              echo "version=${dep_version#v}"
+              echo "skip=false"
+            } >> "$GITHUB_OUTPUT"
           fi
-          
-          echo "name=$dep_name" >> "$GITHUB_OUTPUT"
-          echo "version=${dep_version#v}" >> "$GITHUB_OUTPUT"
       - name: Update all Go modules
-        run: |
-          ./scripts/go-update-dep-all.sh ${{ format('{0}@v{1}', steps.deps.outputs.name, steps.deps.outputs.version) }}
-          ./scripts/go-mod-tidy-all.sh
+        if: steps.deps.outputs.skip != 'true'
+        run: ./scripts/go-update-dep-all.sh ${{ format('{0}@v{1}', steps.deps.outputs.name, steps.deps.outputs.version) }}
+      - name: Tidy all Go modules
+        run: ./scripts/go-mod-tidy-all.sh
       - name: Commit changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           default_author: user_info
           message: "${{ github.event.pull_request.title }} for all modules"

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -1,6 +1,10 @@
 name: "Dependency Review"
 on:
   pull_request:
+    paths:
+      - "**/*.go"
+      - "**/go.mod"
+      - "**/go.sum"
   merge_group:
 
 permissions:
@@ -11,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: "Setup Go"
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.10"
           check-latest: true
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v4
@@ -26,22 +30,30 @@ jobs:
       - name: "Go vulnerability check"
         id: govuln
         run: |
-          # Run the vulnerability check and capture its output (ignoring non-zero exit codes)
+          # Known unfixable vulns can be appended here (space-separated GO-IDs).
+          # GO-2025-3443 is a legacy allowlisted entry. Any other GO-ID fails the job.
+          ALLOWED="GO-2025-3443"
+
           if ! make vulncheck 2>&1 | tee govulncheck-output.txt ; then
             echo "govulncheck failed to execute"
             exit 1
           fi
 
-          # Extract vulnerability identifiers from the output (e.g., GO-2025-3443)
-          vulnerabilities=$(grep -o 'GO-[0-9]\{4\}-[0-9]\+' govulncheck-output.txt | sort | uniq)
+          vulnerabilities=$(grep -oE 'GO-[0-9]{4}-[0-9]+' govulncheck-output.txt | sort -u)
           echo "Detected vulnerabilities: $vulnerabilities"
 
-          # Check if any vulnerability other than GO-2025-3443 exists
           for vuln in $vulnerabilities; do
-            if [ "$vuln" != "GO-2025-3443" ]; then
-              echo "Found vulnerability $vuln, failing..."
+            found=false
+            for allow in $ALLOWED; do
+              if [ "$vuln" = "$allow" ]; then
+                found=true
+                break
+              fi
+            done
+            if [ "$found" = false ]; then
+              echo "Unallowed vulnerability $vuln found; failing."
               exit 1
             fi
           done
 
-          echo "Only known vulnerability (GO-2025-3443) present. Continuing."
+          echo "Only known allowlisted vulnerabilities present. Continuing."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * [#1986](https://github.com/crypto-org-chain/cronos/pull/1986) Remove unused precompiles
 * [#2017](https://github.com/crypto-org-chain/cronos/pull/2017) chore(deps): bump ibc to 10.5.1
 * [#2038](https://github.com/crypto-org-chain/cronos/pull/2038) chore(ci): improve ci running
-* [#2044](https://github.com/crypto-org-chain/cronos/pull/2044) chore(ci): add dependabot grouping config; harden dependabot-update-all (pull_request_target, head.sha, grouped-title tolerance); scope dependency review to go diffs.
+* [#2044](https://github.com/crypto-org-chain/cronos/pull/2044) ci: fix dependabot workflows and drain PR backlog
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#1986](https://github.com/crypto-org-chain/cronos/pull/1986) Remove unused precompiles
 * [#2017](https://github.com/crypto-org-chain/cronos/pull/2017) chore(deps): bump ibc to 10.5.1
 * [#2038](https://github.com/crypto-org-chain/cronos/pull/2038) chore(ci): improve ci running
+* chore(ci): add dependabot grouping config; harden dependabot-update-all (pull_request_target, head.sha checkout, gated to dependabot/go_modules/*, grouped-title tolerance); scope dependency review to go diffs.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * [#1986](https://github.com/crypto-org-chain/cronos/pull/1986) Remove unused precompiles
 * [#2017](https://github.com/crypto-org-chain/cronos/pull/2017) chore(deps): bump ibc to 10.5.1
 * [#2038](https://github.com/crypto-org-chain/cronos/pull/2038) chore(ci): improve ci running
-* chore(ci): add dependabot grouping config; harden dependabot-update-all (pull_request_target, head.sha checkout, gated to dependabot/go_modules/*, grouped-title tolerance); scope dependency review to go diffs.
+* [#2044](https://github.com/crypto-org-chain/cronos/pull/2044) chore(ci): add dependabot grouping config; harden dependabot-update-all (pull_request_target, head.sha, grouped-title tolerance); scope dependency review to go diffs.
 
 
 


### PR DESCRIPTION
## Summary
- **dependabot.yml** (new): groups added for all ecosystems — `cosmos-sdk`, `otel`, `gomod-minor-patch` for gomod; `gh-actions` for actions; `docker`; `pip-minor-patch` for integration_tests + testground/benchmark; `npm-minor-patch` for integration_tests/contracts
- **dependabot-update-all**: `pull_request_target` trigger so `APP_ID`/`APP_PRIVATE_KEY` resolve; gate on `dependabot/go_modules/*`; tolerate grouped PR titles (tidy-only fallback); `head.sha` checkout (security); bump `setup-go` → 1.25.10, `checkout` → v6, `add-and-commit` → v10, `create-github-app-token` → v2.2.1
- **dependencies-review**: paths filter scopes to go diffs; `setup-go` → 1.25.10, `checkout` → v6; allowlist refactored to multi-ID variable

## Follow-up (backlog drain post-merge)
- `@dependabot recreate` on surviving standalone PRs (grpc #1989, hashicorp/go-getter #2009)
- `@dependabot close` on PRs that will be covered by new groups → bundled PRs next cycle
- merge order: gomod group → standalone majors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update configuration for ecosystem management.
  * Enhanced CI workflows for dependency reviews and vulnerability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->