### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/cmd/cronosd/dbmigrate/patch.go
+++ b/cmd/cronosd/dbmigrate/patch.go
@@ -1283,10 +1283,7 @@ func formatKeyPrefix(key []byte, maxLen int) string {
 			return "0x"
 		}
 		// Truncate to maxLen-2 to account for "0x" prefix
-		truncLen := maxLen - 2
-		if truncLen > len(hexStr) {
-			truncLen = len(hexStr)
-		}
+		truncLen := min(maxLen-2, len(hexStr))
 		return "0x" + hexStr[:truncLen]
 	}
 	return "0x" + hexStr[:halfLen] + "..." + hexStr[len(hexStr)-halfLen:]

--- a/cmd/cronosd/dbmigrate/patch_advanced_test.go
+++ b/cmd/cronosd/dbmigrate/patch_advanced_test.go
@@ -725,11 +725,3 @@ func TestPatchDryRunDoesNotModify(t *testing.T) {
 		require.Nil(t, hValue, "Height %d should NOT be in target (dry-run)", height)
 	}
 }
-
-// Helper function min for integers
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

And Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 




# PR Checklist:

- [x] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [x] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [x] Have you rebased your work on top of the latest master? 
- [x] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [x] Have you checked your code passes the unit tests? (`make test`)
- [x] Have you checked your code formatting is correct? (`go fmt`)
- [x] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal database migration logic with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->