### PR TITLE
chore(dep): pin ibc-go to upstream v11.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [#2038](https://github.com/crypto-org-chain/cronos/pull/2038) chore(ci): improve ci running
 * [#2048](https://github.com/crypto-org-chain/cronos/pull/2048) refactor: use slices.Contains and strings.ContainsRune to simplify code
 * [#2044](https://github.com/crypto-org-chain/cronos/pull/2044) ci: fix dependabot workflows and drain PR backlog
+* [#2098](https://github.com/crypto-org-chain/cronos/pull/2098) chore(dep): pin ibc-go to upstream v11.1.0
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,7 @@ require (
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/iavl v1.2.8 // indirect
-	github.com/cosmos/ibc-go/v11 v11.0.0
+	github.com/cosmos/ibc-go/v11 v11.1.0
 	github.com/cosmos/ics23/go v0.11.0 // indirect
 	github.com/cosmos/ledger-cosmos-go v1.0.0 // indirect
 	github.com/crate-crypto/go-eth-kzg v1.4.0 // indirect
@@ -389,7 +389,6 @@ replace (
 	// solves bug on pruning "version does not exist"
 	github.com/cosmos/iavl => github.com/cosmos/iavl v1.2.6
 
-	github.com/cosmos/ibc-go/v11 => github.com/crypto-org-chain/ibc-go/v11 v11.0.0-20260601161416-2254d21b6dfe
 	github.com/crypto-org-chain/cronos-store/memiavl => github.com/crypto-org-chain/cronos-store/memiavl v0.0.0-20260529153812-1f2f45ec5a3c
 
 	github.com/crypto-org-chain/cronos-store/store => github.com/crypto-org-chain/cronos-store/store v0.0.0-20260529153812-1f2f45ec5a3c

--- a/go.sum
+++ b/go.sum
@@ -294,8 +294,8 @@ github.com/cosmos/gogoproto v1.7.2 h1:5G25McIraOC0mRFv9TVO139Uh3OklV2hczr13KKVHC
 github.com/cosmos/gogoproto v1.7.2/go.mod h1:8S7w53P1Y1cHwND64o0BnArT6RmdgIvsBuco6uTllsk=
 github.com/cosmos/iavl v1.2.6 h1:Hs3LndJbkIB+rEvToKJFXZvKo6Vy0Ex1SJ54hhtioIs=
 github.com/cosmos/iavl v1.2.6/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
-github.com/cosmos/ibc-go/v11 v11.0.0 h1:9EIehi88hNP1cCU83NC+J8UXNn+05YZt9eqmnzCQLSg=
-github.com/cosmos/ibc-go/v11 v11.0.0/go.mod h1:iWlzLuCu+ctVbQwoVf5z51HE5e/NE8/pwnLVVDmP++4=
+github.com/cosmos/ibc-go/v11 v11.1.0 h1:77RzkIOSZFL1alC7odQG3zZ7wAQkfsiWLV479ase8Dg=
+github.com/cosmos/ibc-go/v11 v11.1.0/go.mod h1:iWlzLuCu+ctVbQwoVf5z51HE5e/NE8/pwnLVVDmP++4=
 github.com/cosmos/ics23/go v0.11.0 h1:jk5skjT0TqX5e5QJbEnwXIS2yI2vnmLOgpQPeM5RtnU=
 github.com/cosmos/ics23/go v0.11.0/go.mod h1:A8OjxPE67hHST4Icw94hOxxFEJMBG031xIGF/JHNIY0=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
@@ -329,8 +329,6 @@ github.com/crypto-org-chain/ethermint v0.22.1-0.20260528204018-f6683e1e255b h1:3
 github.com/crypto-org-chain/ethermint v0.22.1-0.20260528204018-f6683e1e255b/go.mod h1:+KYccHfFJQ6J2gsINufYi4+ZqiTjbjOBYnnsdu6FeLs=
 github.com/crypto-org-chain/go-ethereum v1.10.20-0.20260521015249-663dca6c618e h1:ftyRRWDiXKWsnp3PxLNbfVLzrqkx+aDNZdkPconawWk=
 github.com/crypto-org-chain/go-ethereum v1.10.20-0.20260521015249-663dca6c618e/go.mod h1:Fs6QebQbavneQTYcA39PEKv2+zIjX7rPUZ14DER46wk=
-github.com/crypto-org-chain/ibc-go/v11 v11.0.0-20260601161416-2254d21b6dfe h1:fAMN/waUc5ktvpAaUtOsekTzAKwdP1boM71ONmya/ZQ=
-github.com/crypto-org-chain/ibc-go/v11 v11.0.0-20260601161416-2254d21b6dfe/go.mod h1:iWlzLuCu+ctVbQwoVf5z51HE5e/NE8/pwnLVVDmP++4=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -278,9 +278,8 @@ schema = 3
     hash = "sha256-9kLtVepU5b3m2Sne8pBQNvF9LxM374LEmvuLWeYBfFU="
     replaced = "github.com/cosmos/iavl"
   [mod."github.com/cosmos/ibc-go/v11"]
-    version = "v11.0.0-20260601161416-2254d21b6dfe"
-    hash = "sha256-pmH5/+nDVpBBAg7Q+Ha7bkz0w/ai1Vy/h7FK//17Qvw="
-    replaced = "github.com/crypto-org-chain/ibc-go/v11"
+    version = "v11.1.0"
+    hash = "sha256-wNqlnX3OXFspJlRTmIKd+SjbpU+lCzI5pmv+6sEBiJc="
   [mod."github.com/cosmos/ics23/go"]
     version = "v0.11.0"
     hash = "sha256-mgU/pqp4kASmW/bP0z6PzssfjRp7GU9ioyvNlDdGC+E="

--- a/nix/testenv.nix
+++ b/nix/testenv.nix
@@ -5,7 +5,7 @@
   pkgs,
 }:
 let
-  # Override the default poetry2nix overrides to fix rpds-py
+  # Override the default poetry2nix overrides to fix rpds-py and ckzg wheel builds
   customPoetry2nix = poetry2nix.overrideScope (
     final: prev: {
       defaultPoetryOverrides = prev.defaultPoetryOverrides.extend (
@@ -24,6 +24,30 @@ let
               ];
             }
           );
+          # When preferWheels=true selects the ckzg wheel, the default poetry2nix
+          # override's postPatch tries to patch src/Makefile which doesn't exist
+          # in the wheel. Clear postPatch for wheel builds.
+          ckzg = super.ckzg.overridePythonAttrs (
+            old: lib.optionalAttrs (old.src.isWheel or false) { postPatch = ""; }
+          );
+          # eth-hash, eth-keyfile, eth-keys, web3, rlp: default overrides run
+          # substituteInPlace setup.py in preConfigure, but setup.py doesn't
+          # exist in wheel distributions (preferWheels=true).
+          eth-hash = super.eth-hash.overridePythonAttrs (
+            old: lib.optionalAttrs (old.src.isWheel or false) { preConfigure = ""; }
+          );
+          rlp = super.rlp.overridePythonAttrs (
+            old: lib.optionalAttrs (old.src.isWheel or false) { preConfigure = ""; }
+          );
+          eth-keyfile = super.eth-keyfile.overridePythonAttrs (
+            old: lib.optionalAttrs (old.src.isWheel or false) { preConfigure = ""; }
+          );
+          eth-keys = super.eth-keys.overridePythonAttrs (
+            old: lib.optionalAttrs (old.src.isWheel or false) { preConfigure = ""; }
+          );
+          web3 = super.web3.overridePythonAttrs (
+            old: lib.optionalAttrs (old.src.isWheel or false) { preConfigure = ""; }
+          );
         }
       );
     }
@@ -32,6 +56,7 @@ in
 customPoetry2nix.mkPoetryEnv {
   projectDir = ../integration_tests;
   python = python311;
+  preferWheels = true;
   overrides = customPoetry2nix.overrides.withDefaults (
     self: super:
     let
@@ -58,20 +83,26 @@ customPoetry2nix.mkPoetryEnv {
       })
     ) buildSystems)
     // {
-      typing-extensions = super.typing-extensions.overridePythonAttrs (old: {
-        postPatch = (old.postPatch or "") + ''
-          sed -i '/^license-files = \["LICENSE"\]$/d' pyproject.toml
-          substituteInPlace pyproject.toml \
-            --replace-warn 'license = "PSF-2.0"' 'license = { text = "PSF-2.0" }'
-        '';
-      });
-      types-requests = super.types-requests.overridePythonAttrs (old: {
-        postPatch = (old.postPatch or "") + ''
-          sed -i '/^license-files = \["LICENSE"\]$/d' pyproject.toml
-          substituteInPlace pyproject.toml \
-            --replace-warn 'license = "Apache-2.0"' 'license = { text = "Apache-2.0" }'
-        '';
-      });
+      typing-extensions = super.typing-extensions.overridePythonAttrs (
+        old:
+        lib.optionalAttrs (!(old.src.isWheel or false)) {
+          postPatch = (old.postPatch or "") + ''
+            sed -i '/^license-files = \["LICENSE"\]$/d' pyproject.toml
+            substituteInPlace pyproject.toml \
+              --replace-warn 'license = "PSF-2.0"' 'license = { text = "PSF-2.0" }'
+          '';
+        }
+      );
+      types-requests = super.types-requests.overridePythonAttrs (
+        old:
+        lib.optionalAttrs (!(old.src.isWheel or false)) {
+          postPatch = (old.postPatch or "") + ''
+            sed -i '/^license-files = \["LICENSE"\]$/d' pyproject.toml
+            substituteInPlace pyproject.toml \
+              --replace-warn 'license = "Apache-2.0"' 'license = { text = "Apache-2.0" }'
+          '';
+        }
+      );
     }
   );
 }


### PR DESCRIPTION
Pin ibc-go to upstream v11.1.0, remove cronos fork dependency. #2089 is already included the ibc state store migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the IBC integration dependency to upstream v11.1.0 and removed the previous local replacement.
  * Improved test/build environment handling to prefer wheel packages and adjust build overrides for certain dependencies.
* **Documentation**
  * Added an UNRELEASED changelog entry documenting the dependency update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->