### PR TITLE
fix: bound message count and per-message gas in ReplayBlock query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 * [#2069](https://github.com/crypto-org-chain/cronos/pull/2069) fix(test): flaky test_mempool integration test.
 * [#2071](https://github.com/crypto-org-chain/cronos/pull/2071) fix(test): fix flaky ibc and versiondb integration tests.
 * [#2099](https://github.com/crypto-org-chain/cronos/pull/2099) fix(cronos): add contract authorization check to SendCroToIbcHandler
-* [#XXXX](https://github.com/crypto-org-chain/cronos/pull/XXXX) fix(cronos): bound message count and per-message gas in the ReplayBlock gRPC query.
+* [#2131](https://github.com/crypto-org-chain/cronos/pull/2131) fix(cronos): bound message count and per-message gas in the ReplayBlock gRPC query.
 
 
 ### Chores:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#2069](https://github.com/crypto-org-chain/cronos/pull/2069) fix(test): flaky test_mempool integration test.
 * [#2071](https://github.com/crypto-org-chain/cronos/pull/2071) fix(test): fix flaky ibc and versiondb integration tests.
 * [#2099](https://github.com/crypto-org-chain/cronos/pull/2099) fix(cronos): add contract authorization check to SendCroToIbcHandler
+* [#XXXX](https://github.com/crypto-org-chain/cronos/pull/XXXX) fix(cronos): bound message count and per-message gas in the ReplayBlock gRPC query.
 
 
 ### Chores:

--- a/x/cronos/keeper/grpc_query.go
+++ b/x/cronos/keeper/grpc_query.go
@@ -25,7 +25,7 @@ const (
 	MaxReplayBlockMsgs = 10000
 
 	// DefaultReplayBlockGasCap caps per-message EVM gas when the chain reports no
-	// block gas limit. Mirrors ethermint's default JSON-RPC gas cap.
+	// block gas limit.
 	DefaultReplayBlockGasCap = 25_000_000
 )
 

--- a/x/cronos/keeper/grpc_query.go
+++ b/x/cronos/keeper/grpc_query.go
@@ -3,13 +3,11 @@ package keeper
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/big"
 
 	"github.com/crypto-org-chain/cronos/x/cronos/types"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	ethermint "github.com/evmos/ethermint/types"
 	evmkeeper "github.com/evmos/ethermint/x/evm/keeper"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"google.golang.org/grpc/codes"
@@ -24,9 +22,9 @@ const (
 	// MaxReplayBlockMsgs caps the eth messages one ReplayBlock query may execute.
 	MaxReplayBlockMsgs = 10000
 
-	// DefaultReplayBlockGasCap caps per-message EVM gas when the chain reports no
-	// block gas limit.
-	DefaultReplayBlockGasCap = 25_000_000
+	// ReplayBlockGasCap caps per-message EVM gas in a ReplayBlock query.
+	// Since historical blocks may have used different limits, we use a fixed upper bound value.
+	ReplayBlockGasCap = 60_000_000
 )
 
 var _ types.QueryServer = Keeper{}
@@ -79,10 +77,7 @@ func (k Keeper) ReplayBlock(goCtx context.Context, req *types.ReplayBlockRequest
 
 	// Per-message gas cap. A committed tx already fits within the block gas
 	// limit, so legitimate replay is unaffected.
-	gasCap := ethermint.BlockGasLimit(ctx)
-	if gasCap == 0 || gasCap == math.MaxUint64 {
-		gasCap = DefaultReplayBlockGasCap
-	}
+	gasCap := uint64(ReplayBlockGasCap)
 
 	// load parameters
 	params := k.evmKeeper.GetParams(ctx)

--- a/x/cronos/keeper/grpc_query.go
+++ b/x/cronos/keeper/grpc_query.go
@@ -79,7 +79,6 @@ func (k Keeper) ReplayBlock(goCtx context.Context, req *types.ReplayBlockRequest
 
 	// Per-message gas cap. A committed tx already fits within the block gas
 	// limit, so legitimate replay is unaffected, while a caller can't burn
-	// unbounded CPU with an oversized gas limit on this unmetered query path.
 	gasCap := ethermint.BlockGasLimit(ctx)
 	if gasCap == 0 || gasCap == math.MaxUint64 {
 		gasCap = DefaultReplayBlockGasCap

--- a/x/cronos/keeper/grpc_query.go
+++ b/x/cronos/keeper/grpc_query.go
@@ -3,11 +3,13 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 
 	"github.com/crypto-org-chain/cronos/x/cronos/types"
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	ethermint "github.com/evmos/ethermint/types"
 	evmkeeper "github.com/evmos/ethermint/x/evm/keeper"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"google.golang.org/grpc/codes"
@@ -16,6 +18,16 @@ import (
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	// MaxReplayBlockMsgs caps the eth messages one ReplayBlock query may execute.
+	// A real block never holds this many, so legitimate replay is unaffected.
+	MaxReplayBlockMsgs = 10000
+
+	// DefaultReplayBlockGasCap caps per-message EVM gas when the chain reports no
+	// block gas limit. Mirrors ethermint's default JSON-RPC gas cap.
+	DefaultReplayBlockGasCap = 25_000_000
 )
 
 var _ types.QueryServer = Keeper{}
@@ -52,6 +64,12 @@ func (k Keeper) DenomByContract(goCtx context.Context, req *types.DenomByContrac
 
 // ReplayBlock replay the eth messages in the block to recover the results of false-failed txs.
 func (k Keeper) ReplayBlock(goCtx context.Context, req *types.ReplayBlockRequest) (*types.ReplayBlockResponse, error) {
+	// bound the batch size on this public gRPC endpoint
+	if len(req.Msgs) > MaxReplayBlockMsgs {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"too many messages in ReplayBlock request: %d (max %d)", len(req.Msgs), MaxReplayBlockMsgs)
+	}
+
 	rsps := make([]*evmtypes.MsgEthereumTxResponse, 0, len(req.Msgs))
 
 	// prepare the block context, the multistore version should be setup already in grpc query context.
@@ -59,6 +77,14 @@ func (k Keeper) ReplayBlock(goCtx context.Context, req *types.ReplayBlockRequest
 		WithBlockHeight(req.BlockNumber).
 		WithBlockTime(req.BlockTime).
 		WithHeaderHash(common.Hex2Bytes(req.BlockHash))
+
+	// Per-message gas cap. A committed tx already fits within the block gas
+	// limit, so legitimate replay is unaffected, while a caller can't burn
+	// unbounded CPU with an oversized gas limit on this unmetered query path.
+	gasCap := ethermint.BlockGasLimit(ctx)
+	if gasCap == 0 || gasCap == math.MaxUint64 {
+		gasCap = DefaultReplayBlockGasCap
+	}
 
 	// load parameters
 	params := k.evmKeeper.GetParams(ctx)
@@ -75,6 +101,12 @@ func (k Keeper) ReplayBlock(goCtx context.Context, req *types.ReplayBlockRequest
 
 	// we assume the message executions are successful, they are filtered in json-rpc api
 	for _, msg := range req.Msgs {
+		// reject oversized messages before doing any EVM work
+		if gas := msg.GetGas(); gas > gasCap {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"message gas limit %d exceeds ReplayBlock cap %d", gas, gasCap)
+		}
+
 		// deduct fee
 		// populate the `From` field
 		if _, err := msg.GetSenderLegacy(ethtypes.LatestSignerForChainID(chainID)); err != nil {

--- a/x/cronos/keeper/grpc_query.go
+++ b/x/cronos/keeper/grpc_query.go
@@ -78,7 +78,7 @@ func (k Keeper) ReplayBlock(goCtx context.Context, req *types.ReplayBlockRequest
 		WithHeaderHash(common.Hex2Bytes(req.BlockHash))
 
 	// Per-message gas cap. A committed tx already fits within the block gas
-	// limit, so legitimate replay is unaffected, while a caller can't burn
+	// limit, so legitimate replay is unaffected.
 	gasCap := ethermint.BlockGasLimit(ctx)
 	if gasCap == 0 || gasCap == math.MaxUint64 {
 		gasCap = DefaultReplayBlockGasCap

--- a/x/cronos/keeper/grpc_query.go
+++ b/x/cronos/keeper/grpc_query.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	// MaxReplayBlockMsgs caps the eth messages one ReplayBlock query may execute.
-	// A real block never holds this many, so legitimate replay is unaffected.
 	MaxReplayBlockMsgs = 10000
 
 	// DefaultReplayBlockGasCap caps per-message EVM gas when the chain reports no

--- a/x/cronos/keeper/grpc_query.go
+++ b/x/cronos/keeper/grpc_query.go
@@ -97,14 +97,24 @@ func (k Keeper) ReplayBlock(goCtx context.Context, req *types.ReplayBlockRequest
 	evmDenom := params.EvmDenom
 	baseFee := k.evmKeeper.GetBaseFee(ctx, ethCfg)
 
-	// we assume the message executions are successful, they are filtered in json-rpc api
+	// gas budget is 2 times the gas cap because the last transaction can be overload the gas limit in case of legacy blocks
+	gasBudget := gasCap * 2
+	var cumulativeGas uint64
 	for _, msg := range req.Msgs {
-		// reject oversized messages before doing any EVM work
-		if gas := msg.GetGas(); gas > gasCap {
+		gas := msg.GetGas()
+		if gas > gasCap {
 			return nil, status.Errorf(codes.InvalidArgument,
 				"message gas limit %d exceeds ReplayBlock cap %d", gas, gasCap)
 		}
+		if gas > gasBudget-cumulativeGas {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"cumulative message gas exceeds ReplayBlock budget %d", gasBudget)
+		}
+		cumulativeGas += gas
+	}
 
+	// we assume the message executions are successful, they are filtered in json-rpc api
+	for _, msg := range req.Msgs {
 		// deduct fee
 		// populate the `From` field
 		if _, err := msg.GetSenderLegacy(ethtypes.LatestSignerForChainID(chainID)); err != nil {

--- a/x/cronos/keeper/grpc_query_test.go
+++ b/x/cronos/keeper/grpc_query_test.go
@@ -1,0 +1,81 @@
+package keeper_test
+
+import (
+	"math/big"
+
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	cronoskeeper "github.com/crypto-org-chain/cronos/x/cronos/keeper"
+	"github.com/crypto-org-chain/cronos/x/cronos/types"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+)
+
+// TestReplayBlockBounds exercises the DoS bounds on the public ReplayBlock
+// gRPC query: the message-count cap, the per-message gas cap, and the
+// cumulative gas budget.
+func (suite *KeeperTestSuite) TestReplayBlockBounds() {
+	const maxGas = 10_000_000
+
+	// pin the block gas limit so gasCap is deterministic regardless of the
+	// ambient consensus params.
+	ctx := suite.ctx.WithConsensusParams(tmproto.ConsensusParams{
+		Block: &tmproto.BlockParams{MaxGas: maxGas},
+	})
+
+	newMsg := func(gas uint64) *evmtypes.MsgEthereumTx {
+		return evmtypes.NewTx(big.NewInt(1), 0, &suite.address, big.NewInt(0), gas, big.NewInt(1), nil, nil, nil, nil)
+	}
+
+	testCases := []struct {
+		name string
+		msgs []*evmtypes.MsgEthereumTx
+		// errMatch is the substring expected in the rejection error; empty means
+		// the request must not be rejected by any of the bounds.
+		errMatch string
+	}{
+		{
+			name:     "too many messages",
+			msgs:     make([]*evmtypes.MsgEthereumTx, cronoskeeper.MaxReplayBlockMsgs+1),
+			errMatch: "too many messages",
+		},
+		{
+			name:     "per-message gas cap",
+			msgs:     []*evmtypes.MsgEthereumTx{newMsg(maxGas + 1)},
+			errMatch: "exceeds ReplayBlock cap",
+		},
+		{
+			name: "cumulative gas budget",
+			// each message is within the per-message cap, but together they
+			// exceed the 2*gasCap cumulative budget.
+			msgs:     []*evmtypes.MsgEthereumTx{newMsg(maxGas), newMsg(maxGas), newMsg(maxGas)},
+			errMatch: "cumulative message gas exceeds",
+		},
+		{
+			name: "boundary block not rejected by bounds",
+			// a real block sums to at most 2*gasCap (block limit plus one final
+			// boundary tx); such a batch must pass all the bounds and only fail
+			// later in the EVM execution path.
+			msgs:     []*evmtypes.MsgEthereumTx{newMsg(maxGas), newMsg(maxGas)},
+			errMatch: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			req := &types.ReplayBlockRequest{
+				Msgs:        tc.msgs,
+				BlockNumber: 1,
+				BlockTime:   ctx.BlockTime(),
+			}
+			_, err := suite.app.CronosKeeper.ReplayBlock(ctx, req)
+			suite.Require().Error(err)
+			if tc.errMatch != "" {
+				suite.Require().Contains(err.Error(), tc.errMatch)
+			} else {
+				// not rejected by the DoS bounds; fails later (e.g. signer/fee).
+				suite.Require().NotContains(err.Error(), "exceeds ReplayBlock cap")
+				suite.Require().NotContains(err.Error(), "cumulative message gas exceeds")
+				suite.Require().NotContains(err.Error(), "too many messages")
+			}
+		})
+	}
+}

--- a/x/cronos/keeper/grpc_query_test.go
+++ b/x/cronos/keeper/grpc_query_test.go
@@ -3,7 +3,6 @@ package keeper_test
 import (
 	"math/big"
 
-	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cronoskeeper "github.com/crypto-org-chain/cronos/x/cronos/keeper"
 	"github.com/crypto-org-chain/cronos/x/cronos/types"
 	evmtypes "github.com/evmos/ethermint/x/evm/types"
@@ -13,13 +12,9 @@ import (
 // gRPC query: the message-count cap, the per-message gas cap, and the
 // cumulative gas budget.
 func (suite *KeeperTestSuite) TestReplayBlockBounds() {
-	const maxGas = 10_000_000
-
-	// pin the block gas limit so gasCap is deterministic regardless of the
-	// ambient consensus params.
-	ctx := suite.ctx.WithConsensusParams(tmproto.ConsensusParams{
-		Block: &tmproto.BlockParams{MaxGas: maxGas},
-	})
+	// The block gas limit is unavailable in the query context, so the gas cap
+	// is the fixed ReplayBlockGasCap constant.
+	const gasCap = cronoskeeper.ReplayBlockGasCap
 
 	newMsg := func(gas uint64) *evmtypes.MsgEthereumTx {
 		return evmtypes.NewTx(big.NewInt(1), 0, &suite.address, big.NewInt(0), gas, big.NewInt(1), nil, nil, nil, nil)
@@ -39,14 +34,14 @@ func (suite *KeeperTestSuite) TestReplayBlockBounds() {
 		},
 		{
 			name:     "per-message gas cap",
-			msgs:     []*evmtypes.MsgEthereumTx{newMsg(maxGas + 1)},
+			msgs:     []*evmtypes.MsgEthereumTx{newMsg(gasCap + 1)},
 			errMatch: "exceeds ReplayBlock cap",
 		},
 		{
 			name: "cumulative gas budget",
 			// each message is within the per-message cap, but together they
 			// exceed the 2*gasCap cumulative budget.
-			msgs:     []*evmtypes.MsgEthereumTx{newMsg(maxGas), newMsg(maxGas), newMsg(maxGas)},
+			msgs:     []*evmtypes.MsgEthereumTx{newMsg(gasCap), newMsg(gasCap), newMsg(gasCap)},
 			errMatch: "cumulative message gas exceeds",
 		},
 		{
@@ -54,7 +49,7 @@ func (suite *KeeperTestSuite) TestReplayBlockBounds() {
 			// a real block sums to at most 2*gasCap (block limit plus one final
 			// boundary tx); such a batch must pass all the bounds and only fail
 			// later in the EVM execution path.
-			msgs:     []*evmtypes.MsgEthereumTx{newMsg(maxGas), newMsg(maxGas)},
+			msgs:     []*evmtypes.MsgEthereumTx{newMsg(gasCap), newMsg(gasCap)},
 			errMatch: "",
 		},
 	}
@@ -64,9 +59,9 @@ func (suite *KeeperTestSuite) TestReplayBlockBounds() {
 			req := &types.ReplayBlockRequest{
 				Msgs:        tc.msgs,
 				BlockNumber: 1,
-				BlockTime:   ctx.BlockTime(),
+				BlockTime:   suite.ctx.BlockTime(),
 			}
-			_, err := suite.app.CronosKeeper.ReplayBlock(ctx, req)
+			_, err := suite.app.CronosKeeper.ReplayBlock(suite.ctx, req)
 			suite.Require().Error(err)
 			if tc.errMatch != "" {
 				suite.Require().Contains(err.Error(), tc.errMatch)


### PR DESCRIPTION
👮🏻👮🏻👮🏻 !!!! REFERENCE THE PROBLEM YOUR ARE SOLVING IN THE PR TITLE AND DESCRIBE YOUR SOLUTION HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻

## Summary

The `ReplayBlock` gRPC query re-executes a batch of caller-supplied eth messages
without a persistent fee, making it an amplification vector on the public gRPC
endpoint: a single request could enqueue an unbounded number of messages, each
carrying an arbitrarily large gas limit, and burn unbounded node CPU.

This adds two bounds:

- **Message count** — reject requests with more than `MaxReplayBlockMsgs` (10000)
  messages. A real block never holds this many eth txs, so the legitimate
  `cronos_replayBlock` JSON-RPC path is unaffected.
- **Per-message gas** — reject any message whose gas limit exceeds the block gas
  limit (`ethermint.BlockGasLimit`), falling back to `DefaultReplayBlockGasCap`
  (25M, matching ethermint's default JSON-RPC gas cap) when the chain reports no
  block gas limit. A committed tx always fits within the block gas limit, so
  legitimate replay is unaffected.

The fallback also treats CometBFT's `max_gas = -1` ("no limit", surfaced as
`math.MaxUint64`) as "no limit", so the gas cap stays effective on chains that
disable the block gas limit.

# PR Checklist:

- [ ] Have you read the [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md)?
- [ ] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [ ] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-org-chain/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-org-chain/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened `ReplayBlock` gRPC limits by rejecting requests that exceed the maximum message count and enforcing per-message and cumulative gas caps to reduce resource-heavy replays.
  * Added explicit boundary coverage to ensure requests at the allowed limits aren’t rejected by the new bounding checks.
* **Tests**
  * Added automated coverage validating message-count and gas-bound rejection behavior for `ReplayBlock`.
* **Documentation**
  * Updated the unreleased changelog to highlight the `ReplayBlock` request bounding improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->