### PR TITLE
feat(mempool): honor CometBFT's mempool.recheck config in app mempool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#2119](https://github.com/crypto-org-chain/cronos/pull/2119) feat(mempool): support direct insert tx via app mempool.
 * [#2120](https://github.com/crypto-org-chain/cronos/pull/2120) feat(ante): wire ethermint NewEVMSigPreVerifier for lock-free admission, via an app-owned PreVerifierRegistry that composes per-module verifiers.
 * [#2127](https://github.com/crypto-org-chain/cronos/pull/2127) feat(mempool): back txpool RPC with app mempool PendingTxs.
+* [#2139](https://github.com/crypto-org-chain/cronos/pull/2139) feat(mempool): honor CometBFT's mempool.recheck config in app mempool.
 
 ### Bug fixes
 

--- a/app/app.go
+++ b/app/app.go
@@ -179,6 +179,7 @@ const (
 	FlagMempoolFeeBump    = "mempool.feebump"
 	FlagMempoolType       = "mempool.type"
 	FlagMempoolMaxTxBytes = "mempool.max_tx_bytes" // CometBFT mapstructure key uses underscore
+	FlagMempoolRecheck    = "mempool.recheck"      // CometBFT's own recheck toggle; app-mempool recheck honors it too
 
 	FlagDisableTxReplacement       = "cronos.disable-tx-replacement"
 	FlagDisableOptimisticExecution = "cronos.disable-optimistic-execution"
@@ -459,6 +460,22 @@ func New(
 		}
 		ttlNumBlocks = parsed
 	}
+	// recheckEnabled mirrors CometBFT's mempool.recheck (default true).
+	recheckEnabled := true
+	if v := appOpts.Get(FlagMempoolRecheck); v != nil {
+		// cast.ToBoolE silently coerces nonzero numbers (e.g. 2) to true.
+		switch v.(type) {
+		case bool, string:
+		default:
+			panic(fmt.Errorf("invalid %s %v: must be a boolean, got %T", FlagMempoolRecheck, v, v))
+		}
+		parsed, err := cast.ToBoolE(v)
+		if err != nil {
+			// v is a string here (bool never errors, other types panicked above).
+			panic(fmt.Errorf("invalid %s %q: must be a boolean", FlagMempoolRecheck, v))
+		}
+		recheckEnabled = parsed
+	}
 	if mempoolMaxTxs >= 0 && feeBump >= 0 {
 		// NOTE we use custom transaction decoder that supports the sdk.Tx interface instead of sdk.StdTx
 		// Setup Mempool and Proposal Handlers
@@ -549,9 +566,15 @@ func New(
 		// ReapTxsHandler honors MaxBytes/MaxGas hints from the CometBFT AppReactor.
 		if mempoolType == cronosmempool.TypeApp {
 			logger.Info("AppMempool ABCI hooks enabled", "type", mempoolType)
+			if !recheckEnabled {
+				logger.Warn("mempool.recheck=false: post-commit re-validation disabled; a tx invalidated by a sibling's eviction is only caught by its own TTL/timeout, if any")
+				if ttlNumBlocks == 0 {
+					logger.Warn("mempool.recheck=false with mempool.ttl-num-blocks=0: an invalidated tx with no declared timeout is never evicted and may be reproposed indefinitely")
+				}
+			}
 
 			app.SetReapTxsHandler(cronosmempool.NewReapTxsHandler(mpool, txConfig.TxEncoder(), encCache, gossipTTL, txsPerBlock, logger.With("module", "app-mempool")))
-			manager := cronosmempool.NewManager(app, encCache, txConfig.TxEncoder(), mpool, signerExtractor, activeDecoder, txsPerBlock, ttlNumBlocks)
+			manager := cronosmempool.NewManager(app, encCache, txConfig.TxEncoder(), mpool, signerExtractor, activeDecoder, txsPerBlock, ttlNumBlocks, recheckEnabled)
 			var preVerifiers cronosmempool.PreVerifierRegistry
 			// Register EVM module preverifier
 			preVerifiers.Register(appmempool.NewEVMSigPreVerifier(chainId, activeDecoder))

--- a/app/app.go
+++ b/app/app.go
@@ -460,22 +460,6 @@ func New(
 		}
 		ttlNumBlocks = parsed
 	}
-	// recheckEnabled mirrors CometBFT's mempool.recheck (default true).
-	recheckEnabled := true
-	if v := appOpts.Get(FlagMempoolRecheck); v != nil {
-		// cast.ToBoolE silently coerces nonzero numbers (e.g. 2) to true.
-		switch v.(type) {
-		case bool, string:
-		default:
-			panic(fmt.Errorf("invalid %s %v: must be a boolean, got %T", FlagMempoolRecheck, v, v))
-		}
-		parsed, err := cast.ToBoolE(v)
-		if err != nil {
-			// v is a string here (bool never errors, other types panicked above).
-			panic(fmt.Errorf("invalid %s %q: must be a boolean", FlagMempoolRecheck, v))
-		}
-		recheckEnabled = parsed
-	}
 	if mempoolMaxTxs >= 0 && feeBump >= 0 {
 		// NOTE we use custom transaction decoder that supports the sdk.Tx interface instead of sdk.StdTx
 		// Setup Mempool and Proposal Handlers
@@ -503,6 +487,25 @@ func New(
 	case "", "flood", cronosmempool.TypeApp:
 	default:
 		panic(fmt.Sprintf("unrecognized mempool.type %q; valid values: app, flood, \"\"", mempoolType))
+	}
+	// recheckEnabled mirrors CometBFT's mempool.recheck (default true); only
+	// meaningful for mempool.type=app, so parsed (and possibly panics) only then.
+	recheckEnabled := true
+	if mempoolType == cronosmempool.TypeApp {
+		if v := appOpts.Get(FlagMempoolRecheck); v != nil {
+			// cast.ToBoolE silently coerces nonzero numbers (e.g. 2) to true.
+			switch v.(type) {
+			case bool, string:
+			default:
+				panic(fmt.Errorf("invalid %s %v: must be a boolean, got %T", FlagMempoolRecheck, v, v))
+			}
+			parsed, err := cast.ToBoolE(v)
+			if err != nil {
+				// v is a string here (bool never errors, other types panicked above).
+				panic(fmt.Errorf("invalid %s %q: must be a boolean", FlagMempoolRecheck, v))
+			}
+			recheckEnabled = parsed
+		}
 	}
 	if _, isNoOp := mpool.(mempool.NoOpMempool); isNoOp && mempoolType == cronosmempool.TypeApp {
 		// type=app builds blocks by reaping the app mempool; NoOpMempool can't propose.

--- a/app/app.go
+++ b/app/app.go
@@ -577,7 +577,7 @@ func New(
 			}
 
 			app.SetReapTxsHandler(cronosmempool.NewReapTxsHandler(mpool, txConfig.TxEncoder(), encCache, gossipTTL, txsPerBlock, logger.With("module", "app-mempool")))
-			manager := cronosmempool.NewManager(app, encCache, txConfig.TxEncoder(), mpool, signerExtractor, activeDecoder, txsPerBlock, ttlNumBlocks, recheckEnabled)
+			manager := cronosmempool.NewManager(app, encCache, txConfig.TxEncoder(), mpool, signerExtractor, activeDecoder, txsPerBlock, ttlNumBlocks, !recheckEnabled)
 			var preVerifiers cronosmempool.PreVerifierRegistry
 			// Register EVM module preverifier
 			preVerifiers.Register(appmempool.NewEVMSigPreVerifier(chainId, activeDecoder))

--- a/app/app.go
+++ b/app/app.go
@@ -570,10 +570,7 @@ func New(
 		if mempoolType == cronosmempool.TypeApp {
 			logger.Info("AppMempool ABCI hooks enabled", "type", mempoolType)
 			if !recheckEnabled {
-				logger.Warn("mempool.recheck=false: post-commit re-validation disabled; a tx invalidated by a sibling's eviction is only caught by its own TTL/timeout, if any")
-				if ttlNumBlocks == 0 {
-					logger.Warn("mempool.recheck=false with mempool.ttl-num-blocks=0: an invalidated tx with no declared timeout is never evicted and may be reproposed indefinitely")
-				}
+				logger.Warn("mempool.recheck=false: all post-commit rechecking is disabled, including TTL/timeout eviction; a tx invalidated by a sibling's eviction is never evicted and may be reproposed indefinitely")
 			}
 
 			app.SetReapTxsHandler(cronosmempool.NewReapTxsHandler(mpool, txConfig.TxEncoder(), encCache, gossipTTL, txsPerBlock, logger.With("module", "app-mempool")))

--- a/app/mempool/manager.go
+++ b/app/mempool/manager.go
@@ -365,6 +365,14 @@ func (a *Manager) drainStaging() (recheckSenders map[string]struct{}, height int
 
 // selectTxs scans the pool to retrieve txs for recheck.
 func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{}, height int64, deferred []sdk.Tx) []sdk.Tx {
+	// Pass 1 (TTL/expiry eviction) always runs; Pass 2 (RunTx recheck candidate
+	// selection) is skipped below when recheckDisabled, so bail before Pass 2's
+	// setup instead of building it just to discard the result.
+	evictedSet, recheckSenders := a.evictStale(snapshot, height, recheckSenders)
+	if a.recheckDisabled {
+		return nil
+	}
+
 	// deferredLive: carried-over tx -> still in pool. Sized to the small carry; nil if none.
 	var deferredLive map[sdk.Tx]bool
 	if len(deferred) > 0 {
@@ -372,48 +380,6 @@ func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{
 		for _, tx := range deferred {
 			deferredLive[tx] = false
 		}
-	}
-
-	var (
-		expiredEvicted float32
-		ttlEvicted     float32
-	)
-	// Rebuild arrival from this cycle's snapshot so txs gone from the pool fall out.
-	var newArrival map[sdk.Tx]int64
-	if a.ttlNumBlocks > 0 {
-		newArrival = make(map[sdk.Tx]int64, len(snapshot))
-	}
-
-	// Pass 1: evictions. Collect senders of evicted txs so their remaining pool txs
-	// (e.g. higher-nonce siblings) are rechecked — they become invalid after the gap.
-	var evictedSet map[sdk.Tx]struct{} // nil until first eviction; nil-map read is safe
-	now := time.Now()
-	for _, tx := range snapshot {
-		if txTimedout(tx, height, now) {
-			evictedSet, recheckSenders = a.evictForRecheck(tx, evictedSet, recheckSenders)
-			expiredEvicted++
-			continue
-		}
-		if a.ttlNumBlocks > 0 {
-			arrived, expired := txTTLExpired(a.arrival, tx, height, a.ttlNumBlocks)
-			if expired {
-				evictedSet, recheckSenders = a.evictForRecheck(tx, evictedSet, recheckSenders)
-				ttlEvicted++
-				continue
-			}
-			newArrival[tx] = arrived
-		}
-	}
-	a.arrival = newArrival
-	if expiredEvicted > 0 {
-		telemetry.IncrCounter(expiredEvicted, "cronos", "mempool", "recheck", "expired")
-	}
-	if ttlEvicted > 0 {
-		telemetry.IncrCounter(ttlEvicted, "cronos", "mempool", "recheck", "ttl_expired")
-	}
-	if a.recheckDisabled {
-		// Pass 2 output would only be discarded by the caller.
-		return nil
 	}
 
 	// Pass 2: candidate selection over surviving (non-evicted) txs.
@@ -456,6 +422,46 @@ func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{
 		ordered = append(ordered, tx)
 	}
 	return ordered
+}
+
+// evictStale runs Pass 1: evicts snapshot's timed-out and TTL-expired txs,
+// folding evicted senders into recheckSenders so Pass 2 can recheck their
+// remaining pool txs (e.g. higher-nonce siblings invalidated by the gap).
+func (a *Manager) evictStale(snapshot []sdk.Tx, height int64, recheckSenders map[string]struct{}) (evictedSet map[sdk.Tx]struct{}, _ map[string]struct{}) {
+	var (
+		expiredEvicted float32
+		ttlEvicted     float32
+	)
+	// Rebuild arrival from this cycle's snapshot so txs gone from the pool fall out.
+	var newArrival map[sdk.Tx]int64
+	if a.ttlNumBlocks > 0 {
+		newArrival = make(map[sdk.Tx]int64, len(snapshot))
+	}
+	now := time.Now()
+	for _, tx := range snapshot {
+		if txTimedout(tx, height, now) {
+			evictedSet, recheckSenders = a.evictForRecheck(tx, evictedSet, recheckSenders)
+			expiredEvicted++
+			continue
+		}
+		if a.ttlNumBlocks > 0 {
+			arrived, expired := txTTLExpired(a.arrival, tx, height, a.ttlNumBlocks)
+			if expired {
+				evictedSet, recheckSenders = a.evictForRecheck(tx, evictedSet, recheckSenders)
+				ttlEvicted++
+				continue
+			}
+			newArrival[tx] = arrived
+		}
+	}
+	a.arrival = newArrival
+	if expiredEvicted > 0 {
+		telemetry.IncrCounter(expiredEvicted, "cronos", "mempool", "recheck", "expired")
+	}
+	if ttlEvicted > 0 {
+		telemetry.IncrCounter(ttlEvicted, "cronos", "mempool", "recheck", "ttl_expired")
+	}
+	return evictedSet, recheckSenders
 }
 
 // evictForRecheck evicts tx, folding its signers into recheckSenders so Pass 2

--- a/app/mempool/manager.go
+++ b/app/mempool/manager.go
@@ -61,16 +61,27 @@ type Manager struct {
 	// Zero-value (trigger nil) when built via the newManager() test constructor;
 	// TriggerRecheck then runs RecheckTxs inline instead of async.
 	worker recheckWorker
+	// recheckDisabled mirrors mempool.recheck=false: skip RunTx(ReCheck) reval;
+	// TTL/expiry eviction still runs. A sibling invalidated by another's
+	// eviction (nonce gap) isn't caught until its own TTL/timeout — or never,
+	// if ttlNumBlocks=0 and it declares no timeout itself.
+	recheckDisabled bool
 }
 
 // NewManager builds the Manager for mempool.type=app;
-func NewManager(app *baseapp.BaseApp, encCache *EncoderCache, txEncoder sdk.TxEncoder, mpool sdkmempool.Mempool, signer sdkmempool.SignerExtractionAdapter, decoder sdk.TxDecoder, recheckBatchSize int, ttlNumBlocks int64) *Manager {
+func NewManager(app *baseapp.BaseApp, encCache *EncoderCache, txEncoder sdk.TxEncoder, mpool sdkmempool.Mempool, signer sdkmempool.SignerExtractionAdapter, decoder sdk.TxDecoder, recheckBatchSize int, ttlNumBlocks int64, recheckEnabled bool) *Manager {
 	a := newManager(app, encCache, txEncoder, decoder)
 	a.trace = app.Trace()
 	a.mpool = mpool
 	a.signer = signer
 	a.maxRecheckBatch = recheckBatchSize
 	a.ttlNumBlocks = ttlNumBlocks
+	a.recheckDisabled = !recheckEnabled
+	recheckEnabledGauge := float32(0)
+	if recheckEnabled {
+		recheckEnabledGauge = 1
+	}
+	telemetry.SetGauge(recheckEnabledGauge, "cronos", "mempool", "recheck", "enabled")
 	a.worker = newRecheckWorker(a.RecheckTxs)
 	a.worker.start()
 	return a
@@ -93,10 +104,15 @@ func newManager(runner txRunner, encCache *EncoderCache, txEncoder sdk.TxEncoder
 	}
 }
 
+// recheckDecodingEnabled gates StageSkippedSenders/StageRecheckSenders's decoding.
+func (a *Manager) recheckDecodingEnabled() bool {
+	return !a.recheckDisabled && a.signer != nil && a.decoder != nil
+}
+
 // StageSkippedSenders merges the senders of proposal-gate-rejected txs into
 // recheckSenders without touching lastCommittedHeight
 func (a *Manager) StageSkippedSenders(txs [][]byte) {
-	if a.signer == nil || a.decoder == nil || len(txs) == 0 {
+	if !a.recheckDecodingEnabled() || len(txs) == 0 {
 		return
 	}
 	senders := make(map[string]struct{}, len(txs))
@@ -167,6 +183,11 @@ func (a *Manager) CountTx() int {
 		return 0
 	}
 	return a.mpool.CountTx()
+}
+
+// RecheckDisabled reports whether mempool.recheck=false was wired in.
+func (a *Manager) RecheckDisabled() bool {
+	return a.recheckDisabled
 }
 
 // admit is the shared admission path: preVerify + decode unlocked (bad txs skip
@@ -259,9 +280,10 @@ func (a *Manager) CheckTxHandler() sdk.CheckTxHandler {
 // committed height.
 func (a *Manager) StageRecheckSenders(height int64, txs [][]byte) {
 	// Decode + extract signers unlocked (the expensive part), then publish height
-	// and recheckSenders in one critical section so a reader never sees a torn update.
+	// and recheckSenders together so a reader never sees a torn update. Height
+	// always stages (TTL eviction needs it every cycle); decode skips when recheckDisabled.
 	var senders map[string]struct{}
-	if a.signer != nil && a.decoder != nil {
+	if a.recheckDecodingEnabled() {
 		senders = make(map[string]struct{}, len(txs))
 		for _, bz := range txs {
 			tx, err := a.decoder(bz)
@@ -328,8 +350,8 @@ func (a *Manager) RecheckTxs() {
 	}
 
 	snapshot := PoolSnapshot(context.Background(), a.mpool)
-	candidates := a.selectTxs(snapshot, recheckSenders, height, deferred)
-	candidates = a.capRecheckTxs(candidates)
+	// selectTxs always runs Pass 1 (TTL/expiry eviction); it returns nil when recheckDisabled.
+	candidates := a.capRecheckTxs(a.selectTxs(snapshot, recheckSenders, height, deferred))
 	a.runRecheck(candidates)
 	telemetry.SetGauge(float32(a.mpool.CountTx()), "cronos", "mempool", "pool", "size")
 }
@@ -392,6 +414,10 @@ func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{
 	if ttlEvicted > 0 {
 		telemetry.IncrCounter(ttlEvicted, "cronos", "mempool", "recheck", "ttl_expired")
 	}
+	if a.recheckDisabled {
+		// Pass 2 output would only be discarded by the caller.
+		return nil
+	}
 
 	// Pass 2: candidate selection over surviving (non-evicted) txs.
 	var candidates []sdk.Tx
@@ -435,10 +461,14 @@ func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{
 	return ordered
 }
 
-// evictForRecheck evicts tx and folds its signers into recheckSenders, allocating
-// evictedSet/recheckSenders lazily so a no-eviction cycle stays alloc-free.
+// evictForRecheck evicts tx, folding its signers into recheckSenders so Pass 2
+// can recheck them — skipped entirely when recheckDisabled, since Pass 2 never
+// runs. evictedSet/recheckSenders allocate lazily so a no-eviction cycle stays alloc-free.
 func (a *Manager) evictForRecheck(tx sdk.Tx, evictedSet map[sdk.Tx]struct{}, recheckSenders map[string]struct{}) (map[sdk.Tx]struct{}, map[string]struct{}) {
 	a.evict(tx)
+	if a.recheckDisabled {
+		return evictedSet, recheckSenders
+	}
 	if evictedSet == nil {
 		evictedSet = make(map[sdk.Tx]struct{})
 	}

--- a/app/mempool/manager.go
+++ b/app/mempool/manager.go
@@ -347,7 +347,6 @@ func (a *Manager) RecheckTxs() {
 	}
 
 	snapshot := PoolSnapshot(context.Background(), a.mpool)
-	// selectTxs returns nil immediately when recheckDisabled.
 	candidates := a.capRecheckTxs(a.selectTxs(snapshot, recheckSenders, height, deferred))
 	a.runRecheck(candidates)
 	telemetry.SetGauge(float32(a.mpool.CountTx()), "cronos", "mempool", "pool", "size")

--- a/app/mempool/manager.go
+++ b/app/mempool/manager.go
@@ -61,9 +61,8 @@ type Manager struct {
 	// Zero-value (trigger nil) when built via the newManager() test constructor;
 	// TriggerRecheck then runs RecheckTxs inline instead of async.
 	worker recheckWorker
-	// recheckDisabled mirrors mempool.recheck=false: skips all rechecking,
-	// including TTL/expiry eviction. Not recommended for production — with
-	// recheck fully off, nothing evicts stale or invalidated txs from the pool.
+	// recheckDisabled mirrors mempool.recheck=false: skips all rechecking.
+	// Not recommended for production.
 	recheckDisabled bool
 }
 
@@ -348,8 +347,7 @@ func (a *Manager) RecheckTxs() {
 	}
 
 	snapshot := PoolSnapshot(context.Background(), a.mpool)
-	// selectTxs returns nil immediately when recheckDisabled — Pass 1
-	// (TTL/expiry eviction) is skipped too, not just Pass 2's RunTx recheck.
+	// selectTxs returns nil immediately when recheckDisabled.
 	candidates := a.capRecheckTxs(a.selectTxs(snapshot, recheckSenders, height, deferred))
 	a.runRecheck(candidates)
 	telemetry.SetGauge(float32(a.mpool.CountTx()), "cronos", "mempool", "pool", "size")
@@ -368,8 +366,6 @@ func (a *Manager) drainStaging() (recheckSenders map[string]struct{}, height int
 // selectTxs scans the pool to retrieve txs for recheck.
 func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{}, height int64, deferred []sdk.Tx) []sdk.Tx {
 	if a.recheckDisabled {
-		// Not recommended for production: this skips Pass 1 (TTL/expiry
-		// eviction) too, so nothing evicts stale txs from the pool.
 		return nil
 	}
 
@@ -462,11 +458,8 @@ func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{
 	return ordered
 }
 
-// evictForRecheck evicts tx, folding its signers into recheckSenders so Pass 2
-// can recheck them. A sibling invalidated by this eviction (e.g. a nonce gap)
-// is then only caught by its own TTL/timeout, or never if ttlNumBlocks=0 and
-// it declares none. evictedSet/recheckSenders allocate lazily so a
-// no-eviction cycle stays alloc-free.
+// evictForRecheck evicts tx and folds its signers into recheckSenders, allocating
+// evictedSet/recheckSenders lazily so a no-eviction cycle stays alloc-free.
 func (a *Manager) evictForRecheck(tx sdk.Tx, evictedSet map[sdk.Tx]struct{}, recheckSenders map[string]struct{}) (map[sdk.Tx]struct{}, map[string]struct{}) {
 	a.evict(tx)
 	if evictedSet == nil {

--- a/app/mempool/manager.go
+++ b/app/mempool/manager.go
@@ -336,7 +336,7 @@ func (a *Manager) WaitForRecheckTimedOut(ctx context.Context, timeout time.Durat
 
 // RecheckTxs evicts pool txs invalidated by the last block.
 func (a *Manager) RecheckTxs() {
-	if a.mpool == nil {
+	if a.mpool == nil || a.recheckDisabled {
 		return
 	}
 	a.recheckMu.Lock() // lock order: see the recheckMu field comment
@@ -347,11 +347,10 @@ func (a *Manager) RecheckTxs() {
 		return
 	}
 
-	if !a.recheckDisabled {
-		snapshot := PoolSnapshot(context.Background(), a.mpool)
-		candidates := a.capRecheckTxs(a.selectTxs(snapshot, recheckSenders, height, deferred))
-		a.runRecheck(candidates)
-	}
+	snapshot := PoolSnapshot(context.Background(), a.mpool)
+	candidates := a.capRecheckTxs(a.selectTxs(snapshot, recheckSenders, height, deferred))
+	a.runRecheck(candidates)
+
 	telemetry.SetGauge(float32(a.mpool.CountTx()), "cronos", "mempool", "pool", "size")
 }
 

--- a/app/mempool/manager.go
+++ b/app/mempool/manager.go
@@ -61,24 +61,22 @@ type Manager struct {
 	// Zero-value (trigger nil) when built via the newManager() test constructor;
 	// TriggerRecheck then runs RecheckTxs inline instead of async.
 	worker recheckWorker
-	// recheckDisabled mirrors mempool.recheck=false: skip RunTx(ReCheck) reval;
-	// TTL/expiry eviction still runs. A sibling invalidated by another's
-	// eviction (nonce gap) isn't caught until its own TTL/timeout — or never,
-	// if ttlNumBlocks=0 and it declares no timeout itself.
+	// recheckDisabled mirrors mempool.recheck=false: skip RunTx(ReCheck)
+	// revalidation; TTL/expiry eviction still runs.
 	recheckDisabled bool
 }
 
 // NewManager builds the Manager for mempool.type=app;
-func NewManager(app *baseapp.BaseApp, encCache *EncoderCache, txEncoder sdk.TxEncoder, mpool sdkmempool.Mempool, signer sdkmempool.SignerExtractionAdapter, decoder sdk.TxDecoder, recheckBatchSize int, ttlNumBlocks int64, recheckEnabled bool) *Manager {
+func NewManager(app *baseapp.BaseApp, encCache *EncoderCache, txEncoder sdk.TxEncoder, mpool sdkmempool.Mempool, signer sdkmempool.SignerExtractionAdapter, decoder sdk.TxDecoder, recheckBatchSize int, ttlNumBlocks int64, recheckDisabled bool) *Manager {
 	a := newManager(app, encCache, txEncoder, decoder)
 	a.trace = app.Trace()
 	a.mpool = mpool
 	a.signer = signer
 	a.maxRecheckBatch = recheckBatchSize
 	a.ttlNumBlocks = ttlNumBlocks
-	a.recheckDisabled = !recheckEnabled
+	a.recheckDisabled = recheckDisabled
 	recheckEnabledGauge := float32(0)
-	if recheckEnabled {
+	if !recheckDisabled {
 		recheckEnabledGauge = 1
 	}
 	telemetry.SetGauge(recheckEnabledGauge, "cronos", "mempool", "recheck", "enabled")
@@ -104,7 +102,7 @@ func newManager(runner txRunner, encCache *EncoderCache, txEncoder sdk.TxEncoder
 	}
 }
 
-// recheckDecodingEnabled gates StageSkippedSenders/StageRecheckSenders's decoding.
+// recheckDecodingEnabled reports whether sender decoding/bookkeeping should run.
 func (a *Manager) recheckDecodingEnabled() bool {
 	return !a.recheckDisabled && a.signer != nil && a.decoder != nil
 }
@@ -185,7 +183,7 @@ func (a *Manager) CountTx() int {
 	return a.mpool.CountTx()
 }
 
-// RecheckDisabled reports whether mempool.recheck=false was wired in.
+// RecheckDisabled reports whether mempool recheck is disabled
 func (a *Manager) RecheckDisabled() bool {
 	return a.recheckDisabled
 }
@@ -280,8 +278,7 @@ func (a *Manager) CheckTxHandler() sdk.CheckTxHandler {
 // committed height.
 func (a *Manager) StageRecheckSenders(height int64, txs [][]byte) {
 	// Decode + extract signers unlocked (the expensive part), then publish height
-	// and recheckSenders together so a reader never sees a torn update. Height
-	// always stages (TTL eviction needs it every cycle); decode skips when recheckDisabled.
+	// and recheckSenders in one critical section so a reader never sees a torn update.
 	var senders map[string]struct{}
 	if a.recheckDecodingEnabled() {
 		senders = make(map[string]struct{}, len(txs))
@@ -463,7 +460,9 @@ func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{
 
 // evictForRecheck evicts tx, folding its signers into recheckSenders so Pass 2
 // can recheck them — skipped entirely when recheckDisabled, since Pass 2 never
-// runs. evictedSet/recheckSenders allocate lazily so a no-eviction cycle stays alloc-free.
+// runs. A sibling invalidated by this eviction (e.g. a nonce gap) is then only
+// caught by its own TTL/timeout, or never if ttlNumBlocks=0 and it declares none.
+// evictedSet/recheckSenders allocate lazily so a no-eviction cycle stays alloc-free.
 func (a *Manager) evictForRecheck(tx sdk.Tx, evictedSet map[sdk.Tx]struct{}, recheckSenders map[string]struct{}) (map[sdk.Tx]struct{}, map[string]struct{}) {
 	a.evict(tx)
 	if a.recheckDisabled {

--- a/app/mempool/manager.go
+++ b/app/mempool/manager.go
@@ -63,7 +63,6 @@ type Manager struct {
 	worker recheckWorker
 	// recheckDisabled mirrors mempool.recheck=false: skips all rechecking,
 	// including TTL/expiry eviction, so nothing evicts stale or invalidated
-	// txs from the pool between blocks.
 	recheckDisabled bool
 }
 

--- a/app/mempool/manager.go
+++ b/app/mempool/manager.go
@@ -365,14 +365,6 @@ func (a *Manager) drainStaging() (recheckSenders map[string]struct{}, height int
 
 // selectTxs scans the pool to retrieve txs for recheck.
 func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{}, height int64, deferred []sdk.Tx) []sdk.Tx {
-	// Pass 1 (TTL/expiry eviction) always runs; Pass 2 (RunTx recheck candidate
-	// selection) is skipped below when recheckDisabled, so bail before Pass 2's
-	// setup instead of building it just to discard the result.
-	evictedSet, recheckSenders := a.evictStale(snapshot, height, recheckSenders)
-	if a.recheckDisabled {
-		return nil
-	}
-
 	// deferredLive: carried-over tx -> still in pool. Sized to the small carry; nil if none.
 	var deferredLive map[sdk.Tx]bool
 	if len(deferred) > 0 {
@@ -380,6 +372,48 @@ func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{
 		for _, tx := range deferred {
 			deferredLive[tx] = false
 		}
+	}
+
+	var (
+		expiredEvicted float32
+		ttlEvicted     float32
+	)
+	// Rebuild arrival from this cycle's snapshot so txs gone from the pool fall out.
+	var newArrival map[sdk.Tx]int64
+	if a.ttlNumBlocks > 0 {
+		newArrival = make(map[sdk.Tx]int64, len(snapshot))
+	}
+
+	// Pass 1: evictions. Collect senders of evicted txs so their remaining pool txs
+	// (e.g. higher-nonce siblings) are rechecked — they become invalid after the gap.
+	var evictedSet map[sdk.Tx]struct{} // nil until first eviction; nil-map read is safe
+	now := time.Now()
+	for _, tx := range snapshot {
+		if txTimedout(tx, height, now) {
+			evictedSet, recheckSenders = a.evictForRecheck(tx, evictedSet, recheckSenders)
+			expiredEvicted++
+			continue
+		}
+		if a.ttlNumBlocks > 0 {
+			arrived, expired := txTTLExpired(a.arrival, tx, height, a.ttlNumBlocks)
+			if expired {
+				evictedSet, recheckSenders = a.evictForRecheck(tx, evictedSet, recheckSenders)
+				ttlEvicted++
+				continue
+			}
+			newArrival[tx] = arrived
+		}
+	}
+	a.arrival = newArrival
+	if expiredEvicted > 0 {
+		telemetry.IncrCounter(expiredEvicted, "cronos", "mempool", "recheck", "expired")
+	}
+	if ttlEvicted > 0 {
+		telemetry.IncrCounter(ttlEvicted, "cronos", "mempool", "recheck", "ttl_expired")
+	}
+	if a.recheckDisabled {
+		// Pass 2 output would only be discarded by the caller.
+		return nil
 	}
 
 	// Pass 2: candidate selection over surviving (non-evicted) txs.
@@ -422,46 +456,6 @@ func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{
 		ordered = append(ordered, tx)
 	}
 	return ordered
-}
-
-// evictStale runs Pass 1: evicts snapshot's timed-out and TTL-expired txs,
-// folding evicted senders into recheckSenders so Pass 2 can recheck their
-// remaining pool txs (e.g. higher-nonce siblings invalidated by the gap).
-func (a *Manager) evictStale(snapshot []sdk.Tx, height int64, recheckSenders map[string]struct{}) (evictedSet map[sdk.Tx]struct{}, _ map[string]struct{}) {
-	var (
-		expiredEvicted float32
-		ttlEvicted     float32
-	)
-	// Rebuild arrival from this cycle's snapshot so txs gone from the pool fall out.
-	var newArrival map[sdk.Tx]int64
-	if a.ttlNumBlocks > 0 {
-		newArrival = make(map[sdk.Tx]int64, len(snapshot))
-	}
-	now := time.Now()
-	for _, tx := range snapshot {
-		if txTimedout(tx, height, now) {
-			evictedSet, recheckSenders = a.evictForRecheck(tx, evictedSet, recheckSenders)
-			expiredEvicted++
-			continue
-		}
-		if a.ttlNumBlocks > 0 {
-			arrived, expired := txTTLExpired(a.arrival, tx, height, a.ttlNumBlocks)
-			if expired {
-				evictedSet, recheckSenders = a.evictForRecheck(tx, evictedSet, recheckSenders)
-				ttlEvicted++
-				continue
-			}
-			newArrival[tx] = arrived
-		}
-	}
-	a.arrival = newArrival
-	if expiredEvicted > 0 {
-		telemetry.IncrCounter(expiredEvicted, "cronos", "mempool", "recheck", "expired")
-	}
-	if ttlEvicted > 0 {
-		telemetry.IncrCounter(ttlEvicted, "cronos", "mempool", "recheck", "ttl_expired")
-	}
-	return evictedSet, recheckSenders
 }
 
 // evictForRecheck evicts tx, folding its signers into recheckSenders so Pass 2

--- a/app/mempool/manager.go
+++ b/app/mempool/manager.go
@@ -62,7 +62,7 @@ type Manager struct {
 	// TriggerRecheck then runs RecheckTxs inline instead of async.
 	worker recheckWorker
 	// recheckDisabled mirrors mempool.recheck=false: skips all rechecking,
-	// including TTL/expiry eviction, so nothing evicts stale or invalidated
+	// including TTL/expiry eviction
 	recheckDisabled bool
 }
 

--- a/app/mempool/manager.go
+++ b/app/mempool/manager.go
@@ -61,8 +61,9 @@ type Manager struct {
 	// Zero-value (trigger nil) when built via the newManager() test constructor;
 	// TriggerRecheck then runs RecheckTxs inline instead of async.
 	worker recheckWorker
-	// recheckDisabled mirrors mempool.recheck=false: skip RunTx(ReCheck)
-	// revalidation; TTL/expiry eviction still runs.
+	// recheckDisabled mirrors mempool.recheck=false: skips all rechecking,
+	// including TTL/expiry eviction. Not recommended for production — with
+	// recheck fully off, nothing evicts stale or invalidated txs from the pool.
 	recheckDisabled bool
 }
 
@@ -347,7 +348,8 @@ func (a *Manager) RecheckTxs() {
 	}
 
 	snapshot := PoolSnapshot(context.Background(), a.mpool)
-	// selectTxs always runs Pass 1 (TTL/expiry eviction); it returns nil when recheckDisabled.
+	// selectTxs returns nil immediately when recheckDisabled — Pass 1
+	// (TTL/expiry eviction) is skipped too, not just Pass 2's RunTx recheck.
 	candidates := a.capRecheckTxs(a.selectTxs(snapshot, recheckSenders, height, deferred))
 	a.runRecheck(candidates)
 	telemetry.SetGauge(float32(a.mpool.CountTx()), "cronos", "mempool", "pool", "size")
@@ -365,6 +367,12 @@ func (a *Manager) drainStaging() (recheckSenders map[string]struct{}, height int
 
 // selectTxs scans the pool to retrieve txs for recheck.
 func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{}, height int64, deferred []sdk.Tx) []sdk.Tx {
+	if a.recheckDisabled {
+		// Not recommended for production: this skips Pass 1 (TTL/expiry
+		// eviction) too, so nothing evicts stale txs from the pool.
+		return nil
+	}
+
 	// deferredLive: carried-over tx -> still in pool. Sized to the small carry; nil if none.
 	var deferredLive map[sdk.Tx]bool
 	if len(deferred) > 0 {
@@ -411,10 +419,6 @@ func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{
 	if ttlEvicted > 0 {
 		telemetry.IncrCounter(ttlEvicted, "cronos", "mempool", "recheck", "ttl_expired")
 	}
-	if a.recheckDisabled {
-		// Pass 2 output would only be discarded by the caller.
-		return nil
-	}
 
 	// Pass 2: candidate selection over surviving (non-evicted) txs.
 	var candidates []sdk.Tx
@@ -459,15 +463,12 @@ func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{
 }
 
 // evictForRecheck evicts tx, folding its signers into recheckSenders so Pass 2
-// can recheck them — skipped entirely when recheckDisabled, since Pass 2 never
-// runs. A sibling invalidated by this eviction (e.g. a nonce gap) is then only
-// caught by its own TTL/timeout, or never if ttlNumBlocks=0 and it declares none.
-// evictedSet/recheckSenders allocate lazily so a no-eviction cycle stays alloc-free.
+// can recheck them. A sibling invalidated by this eviction (e.g. a nonce gap)
+// is then only caught by its own TTL/timeout, or never if ttlNumBlocks=0 and
+// it declares none. evictedSet/recheckSenders allocate lazily so a
+// no-eviction cycle stays alloc-free.
 func (a *Manager) evictForRecheck(tx sdk.Tx, evictedSet map[sdk.Tx]struct{}, recheckSenders map[string]struct{}) (map[sdk.Tx]struct{}, map[string]struct{}) {
 	a.evict(tx)
-	if a.recheckDisabled {
-		return evictedSet, recheckSenders
-	}
 	if evictedSet == nil {
 		evictedSet = make(map[sdk.Tx]struct{})
 	}

--- a/app/mempool/manager.go
+++ b/app/mempool/manager.go
@@ -61,8 +61,9 @@ type Manager struct {
 	// Zero-value (trigger nil) when built via the newManager() test constructor;
 	// TriggerRecheck then runs RecheckTxs inline instead of async.
 	worker recheckWorker
-	// recheckDisabled mirrors mempool.recheck=false: skips all rechecking.
-	// Not recommended for production.
+	// recheckDisabled mirrors mempool.recheck=false: skips all rechecking,
+	// including TTL/expiry eviction, so nothing evicts stale or invalidated
+	// txs from the pool between blocks.
 	recheckDisabled bool
 }
 
@@ -346,9 +347,11 @@ func (a *Manager) RecheckTxs() {
 		return
 	}
 
-	snapshot := PoolSnapshot(context.Background(), a.mpool)
-	candidates := a.capRecheckTxs(a.selectTxs(snapshot, recheckSenders, height, deferred))
-	a.runRecheck(candidates)
+	if !a.recheckDisabled {
+		snapshot := PoolSnapshot(context.Background(), a.mpool)
+		candidates := a.capRecheckTxs(a.selectTxs(snapshot, recheckSenders, height, deferred))
+		a.runRecheck(candidates)
+	}
 	telemetry.SetGauge(float32(a.mpool.CountTx()), "cronos", "mempool", "pool", "size")
 }
 
@@ -362,12 +365,9 @@ func (a *Manager) drainStaging() (recheckSenders map[string]struct{}, height int
 	return recheckSenders, height, deferred
 }
 
-// selectTxs scans the pool to retrieve txs for recheck.
+// selectTxs scans the pool to retrieve txs for recheck. Caller (RecheckTxs)
+// only invokes this when recheck is enabled.
 func (a *Manager) selectTxs(snapshot []sdk.Tx, recheckSenders map[string]struct{}, height int64, deferred []sdk.Tx) []sdk.Tx {
-	if a.recheckDisabled {
-		return nil
-	}
-
 	// deferredLive: carried-over tx -> still in pool. Sized to the small carry; nil if none.
 	var deferredLive map[sdk.Tx]bool
 	if len(deferred) > 0 {

--- a/app/mempool/recheck_test.go
+++ b/app/mempool/recheck_test.go
@@ -668,27 +668,23 @@ func TestRecheckTxs_TTLDisabledKeepsOldTx(t *testing.T) {
 	}
 }
 
-func TestRecheckTxs_RecheckDisabledStillEvictsTTL(t *testing.T) {
+func TestRecheckTxs_RecheckDisabledSkipsTTLEviction(t *testing.T) {
 	f := newRecheckFixture()
 	f.a.recheckDisabled = true
 	f.a.ttlNumBlocks = 5
 	aged := f.add(1, "alice", 0, "alice-0")
 
-	f.a.lastCommittedHeight = 10 // first sighting records arrival=10
+	f.a.lastCommittedHeight = 10 // first sighting would record arrival=10 if TTL ran
 	f.a.RecheckTxs()
-	survivor := f.add(2, "alice", 1, "alice-1") // added after cycle 1: young, arrival=15 below
 	f.a.recheckSenders = map[string]struct{}{sdk.AccAddress("alice").String(): {}}
-	f.a.lastCommittedHeight = 15 // 15-10 == ttl → aged evicted
+	f.a.lastCommittedHeight = 15 // 15-10 == ttl, but recheckDisabled skips the sweep entirely
 	f.a.RecheckTxs()
 
-	if poolHas(f.pool, aged) {
-		t.Fatal("TTL sweep must still evict aged tx when recheck is disabled")
+	if !poolHas(f.pool, aged) {
+		t.Fatal("recheckDisabled must skip TTL eviction too, not just RunTx recheck")
 	}
-	if _, ok := f.enc.Get(aged); ok {
-		t.Fatal("aged tx must be evicted from encCache")
-	}
-	if !poolHas(f.pool, survivor) {
-		t.Fatal("survivor must not be evicted")
+	if f.a.arrival != nil {
+		t.Fatal("recheckDisabled must not build the arrival map")
 	}
 	if len(f.runner.modes) != 0 {
 		t.Fatal("recheckDisabled must never call RunTx, even on a live staged candidate")

--- a/app/mempool/recheck_test.go
+++ b/app/mempool/recheck_test.go
@@ -328,6 +328,26 @@ func TestStageRecheckSenders_NoDepsNoPanic(t *testing.T) {
 	a.RecheckTxs()                                  // mpool nil → no-op
 }
 
+func TestStageRecheckSenders_RecheckDisabledSkipsSendersButStagesHeight(t *testing.T) {
+	tx := &ptrTx{id: 1}
+	signer := fakeSigner{m: map[sdk.Tx][]sdkmempool.SignerData{
+		tx: {sdkmempool.NewSignerData(sdk.AccAddress("alice"), 0)},
+	}}
+	decoder := func(b []byte) (sdk.Tx, error) { return tx, nil }
+	a := newManager(&stubRunner{}, nil, noopEncoder, decoder)
+	a.signer = signer
+	a.recheckDisabled = true
+
+	a.StageRecheckSenders(7, [][]byte{[]byte("x")})
+
+	if a.lastCommittedHeight != 7 {
+		t.Fatalf("height must stage even when recheck disabled, got %d", a.lastCommittedHeight)
+	}
+	if a.recheckSenders != nil {
+		t.Fatal("recheckDisabled must skip decode+merge into recheckSenders")
+	}
+}
+
 // A tx with no encCache entry must still be rechecked via the txEncoder fallback.
 func TestRecheckTxs_EncoderFallbackOnCacheMiss(t *testing.T) {
 	f := newRecheckFixture("enc-1") // encoder yields "enc-<id>"; fail id 1
@@ -648,6 +668,50 @@ func TestRecheckTxs_TTLDisabledKeepsOldTx(t *testing.T) {
 	}
 }
 
+func TestRecheckTxs_RecheckDisabledStillEvictsTTL(t *testing.T) {
+	f := newRecheckFixture()
+	f.a.recheckDisabled = true
+	f.a.ttlNumBlocks = 5
+	aged := f.add(1, "alice", 0, "alice-0")
+
+	f.a.lastCommittedHeight = 10 // first sighting records arrival=10
+	f.a.RecheckTxs()
+	survivor := f.add(2, "alice", 1, "alice-1") // added after cycle 1: young, arrival=15 below
+	f.a.recheckSenders = map[string]struct{}{sdk.AccAddress("alice").String(): {}}
+	f.a.lastCommittedHeight = 15 // 15-10 == ttl → aged evicted
+	f.a.RecheckTxs()
+
+	if poolHas(f.pool, aged) {
+		t.Fatal("TTL sweep must still evict aged tx when recheck is disabled")
+	}
+	if _, ok := f.enc.Get(aged); ok {
+		t.Fatal("aged tx must be evicted from encCache")
+	}
+	if !poolHas(f.pool, survivor) {
+		t.Fatal("survivor must not be evicted")
+	}
+	if len(f.runner.modes) != 0 {
+		t.Fatal("recheckDisabled must never call RunTx, even on a live staged candidate")
+	}
+}
+
+func TestRecheckTxs_RecheckDisabledSkipsCandidateRunTx(t *testing.T) {
+	f := newRecheckFixture()
+	f.a.recheckDisabled = true
+	tx := f.add(1, "alice", 0, "alice-0")
+
+	f.a.recheckSenders = map[string]struct{}{sdk.AccAddress("alice").String(): {}}
+	f.a.lastCommittedHeight = 1
+	f.a.RecheckTxs()
+
+	if !poolHas(f.pool, tx) {
+		t.Fatal("recheckDisabled must not run RunTx reval even with a staged sender")
+	}
+	if len(f.runner.modes) != 0 {
+		t.Fatal("recheckDisabled must never call RunTx")
+	}
+}
+
 // Arrival entries for txs gone from the pool (e.g. included in a block) drop out
 // each cycle, bounding the map to the live pool.
 func TestRecheckTxs_TTLArrivalReconcilesRemovedTxs(t *testing.T) {
@@ -831,6 +895,23 @@ func TestStageSkippedSenders_EmptyIsNoop(t *testing.T) {
 	a.StageSkippedSenders([][]byte{})
 	if a.recheckSenders != nil {
 		t.Fatal("empty input must not allocate recheckSenders")
+	}
+}
+
+func TestStageSkippedSenders_RecheckDisabledSkipsMerge(t *testing.T) {
+	tx := &ptrTx{id: 1}
+	signer := fakeSigner{m: map[sdk.Tx][]sdkmempool.SignerData{
+		tx: {sdkmempool.NewSignerData(sdk.AccAddress("alice"), 0)},
+	}}
+	decoder := func(b []byte) (sdk.Tx, error) { return tx, nil }
+	a := newManager(&stubRunner{}, nil, noopEncoder, decoder)
+	a.signer = signer
+	a.recheckDisabled = true
+
+	a.StageSkippedSenders([][]byte{[]byte("x")})
+
+	if a.recheckSenders != nil {
+		t.Fatal("recheckDisabled must skip decode+merge into recheckSenders")
 	}
 }
 

--- a/app/mempool_recheck_flag_test.go
+++ b/app/mempool_recheck_flag_test.go
@@ -15,8 +15,10 @@ import (
 )
 
 // newAppWithMempoolRecheck tests app.go's flag parsing without a full Setup().
+// mempool.recheck is only parsed under mempool.type=app, so that's set here too.
 func newAppWithMempoolRecheck(v interface{}) func() {
 	opts := baseTestAppOpts(0)
+	opts[FlagMempoolType] = cronosmempool.TypeApp
 	if v != nil {
 		opts[FlagMempoolRecheck] = v
 	}
@@ -44,6 +46,16 @@ func TestNewApp_MempoolRecheckFlagInvalid(t *testing.T) {
 			newAppWithMempoolRecheck(v)()
 		})
 	}
+}
+
+// mempool.recheck is irrelevant outside mempool.type=app, so an invalid value
+// there must not panic.
+func TestNewApp_MempoolRecheckFlagInvalidIgnoredWithoutAppMempool(t *testing.T) {
+	opts := baseTestAppOpts(0)
+	opts[FlagMempoolRecheck] = "not-a-bool"
+	require.NotPanics(t, func() {
+		New(log.NewNopLogger(), dbm.NewMemDB(), true, opts, baseapp.SetChainID(TestAppChainID))
+	})
 }
 
 // Unlike the parse-only tests above, this checks the flag actually reaches Manager.

--- a/app/mempool_recheck_flag_test.go
+++ b/app/mempool_recheck_flag_test.go
@@ -1,0 +1,62 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log/v2"
+
+	baseapp "github.com/cosmos/cosmos-sdk/baseapp"
+
+	cronosmempool "github.com/crypto-org-chain/cronos/app/mempool"
+)
+
+// newAppWithMempoolRecheck tests app.go's flag parsing without a full Setup().
+func newAppWithMempoolRecheck(v interface{}) func() {
+	opts := baseTestAppOpts(0)
+	if v != nil {
+		opts[FlagMempoolRecheck] = v
+	}
+	return func() {
+		New(log.NewNopLogger(), dbm.NewMemDB(), true, opts, baseapp.SetChainID(TestAppChainID))
+	}
+}
+
+func TestNewApp_MempoolRecheckFlagUnset(t *testing.T) {
+	require.NotPanics(t, newAppWithMempoolRecheck(nil))
+}
+
+func TestNewApp_MempoolRecheckFlagInvalid(t *testing.T) {
+	cases := map[string]interface{}{
+		"unparseable string":   "not-a-bool",
+		"non-bool/string type": 2,
+	}
+	for name, v := range cases {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				require.NotNil(t, r, "expected a panic")
+				require.Contains(t, fmt.Sprint(r), FlagMempoolRecheck)
+			}()
+			newAppWithMempoolRecheck(v)()
+		})
+	}
+}
+
+// Unlike the parse-only tests above, this checks the flag actually reaches Manager.
+func TestNewApp_MempoolRecheckFlagWiredIntoManager(t *testing.T) {
+	opts := baseTestAppOpts(0)
+	opts[FlagMempoolType] = cronosmempool.TypeApp
+	opts[FlagMempoolRecheck] = false
+
+	a := New(log.NewNopLogger(), dbm.NewMemDB(), true, opts, baseapp.SetChainID(TestAppChainID))
+	t.Cleanup(func() { require.NoError(t, a.Close()) })
+
+	manager := a.MempoolManager()
+	require.NotNil(t, manager, "mempool.type=app must build a Manager")
+	require.True(t, manager.RecheckDisabled(), "mempool.recheck=false must reach Manager.recheckDisabled")
+}
+

--- a/app/mempool_recheck_flag_test.go
+++ b/app/mempool_recheck_flag_test.go
@@ -5,13 +5,12 @@ import (
 	"testing"
 
 	dbm "github.com/cosmos/cosmos-db"
+	cronosmempool "github.com/crypto-org-chain/cronos/app/mempool"
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/log/v2"
 
 	baseapp "github.com/cosmos/cosmos-sdk/baseapp"
-
-	cronosmempool "github.com/crypto-org-chain/cronos/app/mempool"
 )
 
 // newAppWithMempoolRecheck tests app.go's flag parsing without a full Setup().
@@ -71,4 +70,3 @@ func TestNewApp_MempoolRecheckFlagWiredIntoManager(t *testing.T) {
 	require.NotNil(t, manager, "mempool.type=app must build a Manager")
 	require.True(t, manager.RecheckDisabled(), "mempool.recheck=false must reach Manager.recheckDisabled")
 }
-

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -67,12 +67,17 @@ var DefaultConsensusParams = &tmproto.ConsensusParams{
 	},
 }
 
-func setup(withGenesis bool, invCheckPeriod uint) (*App, GenesisState) {
-	db := dbm.NewMemDB()
-	opts := simtestutil.AppOptionsMap{
+// baseTestAppOpts lets callers layer extra flags on before calling New().
+func baseTestAppOpts(invCheckPeriod uint) simtestutil.AppOptionsMap {
+	return simtestutil.AppOptionsMap{
 		flags.FlagHome:            app.DefaultNodeHome,
 		server.FlagInvCheckPeriod: invCheckPeriod,
 	}
+}
+
+func setup(withGenesis bool, invCheckPeriod uint) (*App, GenesisState) {
+	db := dbm.NewMemDB()
+	opts := baseTestAppOpts(invCheckPeriod)
 	app := New(
 		log.NewNopLogger(), db, true,
 		opts,


### PR DESCRIPTION
mempool.type=app currently always revalidates pool txs after commit, ignoring CometBFT's own `mempool.recheck` config.toml setting. This wires that same key into the app-side `Manager`, matching the precedent set by `mempool.type`/`mempool.max_tx_bytes`.

- Read `mempool.recheck` from the merged viper config; only parsed when `mempool.type=app`, so an invalid value doesn't panic for other mempool types
- Pass `recheckDisabled` into `mempool.NewManager`; when true, all rechecking is skipped. Not recommended for production: nothing evicts stale or invalidated txs from the pool between blocks
- Warn at startup when disabled, including an extra warning if `mempool.ttl-num-blocks=0` (an invalidated tx with no declared timeout could then be reproposed indefinitely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for honoring `mempool.recheck` for the application mempool (including a new `mempool.recheck` flag).
  * When disabled, post-commit transaction rechecking is turned off and the mempool emits warnings and telemetry to reflect it.
* **Bug Fixes**
  * Added strict validation for `mempool.recheck` inputs (only `bool` or parseable `string` values are accepted), with clear failures on invalid values.
* **Tests**
  * Expanded coverage for disabled-recheck behavior, including sender staging, TTL/timeout skipping, and avoiding candidate `RunTx` execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->