### PR TITLE
fix(cronos): bound ReplayBlock message count during decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 *Jul 16, 2026*
 
+### Bug fixes
+
+* [#2146](https://github.com/crypto-org-chain/cronos/pull/2146) fix(cronos): bound ReplayBlock message count during decode.
+
 ## v1.8.0-alpha
 
 ### Improvements

--- a/x/cronos/keeper/grpc_query.go
+++ b/x/cronos/keeper/grpc_query.go
@@ -18,14 +18,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-const (
-	// MaxReplayBlockMsgs caps the eth messages one ReplayBlock query may execute.
-	MaxReplayBlockMsgs = 10000
-
-	// ReplayBlockGasCap caps per-message EVM gas in a ReplayBlock query.
-	// Since historical blocks may have used different limits, we use a fixed upper bound value.
-	ReplayBlockGasCap = 60_000_000
-)
+// ReplayBlockGasCap caps per-message EVM gas in a ReplayBlock query.
+// Since historical blocks may have used different limits, we use a fixed upper bound value.
+const ReplayBlockGasCap = 60_000_000
 
 var _ types.QueryServer = Keeper{}
 
@@ -62,9 +57,9 @@ func (k Keeper) DenomByContract(goCtx context.Context, req *types.DenomByContrac
 // ReplayBlock replay the eth messages in the block to recover the results of false-failed txs.
 func (k Keeper) ReplayBlock(goCtx context.Context, req *types.ReplayBlockRequest) (*types.ReplayBlockResponse, error) {
 	// bound the batch size on this public gRPC endpoint
-	if len(req.Msgs) > MaxReplayBlockMsgs {
+	if len(req.Msgs) > types.MaxReplayBlockMsgs {
 		return nil, status.Errorf(codes.InvalidArgument,
-			"too many messages in ReplayBlock request: %d (max %d)", len(req.Msgs), MaxReplayBlockMsgs)
+			"too many messages in ReplayBlock request: %d (max %d)", len(req.Msgs), types.MaxReplayBlockMsgs)
 	}
 
 	rsps := make([]*evmtypes.MsgEthereumTxResponse, 0, len(req.Msgs))

--- a/x/cronos/keeper/grpc_query_test.go
+++ b/x/cronos/keeper/grpc_query_test.go
@@ -29,7 +29,7 @@ func (suite *KeeperTestSuite) TestReplayBlockBounds() {
 	}{
 		{
 			name:     "too many messages",
-			msgs:     make([]*evmtypes.MsgEthereumTx, cronoskeeper.MaxReplayBlockMsgs+1),
+			msgs:     make([]*evmtypes.MsgEthereumTx, types.MaxReplayBlockMsgs+1),
 			errMatch: "too many messages",
 		},
 		{

--- a/x/cronos/types/query.go
+++ b/x/cronos/types/query.go
@@ -4,6 +4,11 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 )
 
+// MaxReplayBlockMsgs caps eth messages per ReplayBlock query. Also enforced
+// in ReplayBlockRequest.Unmarshal (query.pb.go) to stop decode-time OOM —
+// re-add that check by hand if query.pb.go is regenerated.
+const MaxReplayBlockMsgs = 10000
+
 func (m ReplayBlockRequest) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
 	for _, msg := range m.Msgs {
 		if err := msg.UnpackInterfaces(unpacker); err != nil {

--- a/x/cronos/types/query.pb.go
+++ b/x/cronos/types/query.pb.go
@@ -1910,6 +1910,11 @@ func (m *ReplayBlockRequest) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
+			// Hand-maintained cap (see query.go): reject before appending, so a
+			// huge attacker batch can't OOM us before the keeper ever runs.
+			if len(m.Msgs) >= MaxReplayBlockMsgs {
+				return fmt.Errorf("proto: ReplayBlockRequest.Msgs exceeds max allowed count %d", MaxReplayBlockMsgs)
+			}
 			m.Msgs = append(m.Msgs, &types.MsgEthereumTx{})
 			if err := m.Msgs[len(m.Msgs)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/x/cronos/types/query_test.go
+++ b/x/cronos/types/query_test.go
@@ -1,0 +1,40 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReplayBlockRequestUnmarshalCapsMsgs ensures the generated
+// ReplayBlockRequest.Unmarshal aborts once the wire-encoded Msgs field
+// exceeds MaxReplayBlockMsgs, instead of decoding the whole attacker-supplied
+// batch first. Each empty MsgEthereumTx element encodes as just the 2-byte
+// field-1 tag+length, so this reproduces the CC-271 decode-time OOM shape
+// without needing megabytes of payload.
+func TestReplayBlockRequestUnmarshalCapsMsgs(t *testing.T) {
+	elem := []byte{0x0a, 0x00} // field 1, wiretype 2 (length-delimited), length 0
+
+	buildPayload := func(count int) []byte {
+		data := make([]byte, 0, len(elem)*count)
+		for i := 0; i < count; i++ {
+			data = append(data, elem...)
+		}
+		return data
+	}
+
+	t.Run("over cap rejected before fully decoding", func(t *testing.T) {
+		m := &ReplayBlockRequest{}
+		err := m.Unmarshal(buildPayload(MaxReplayBlockMsgs + 1))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds max allowed count")
+		require.LessOrEqual(t, len(m.Msgs), MaxReplayBlockMsgs)
+	})
+
+	t.Run("at cap accepted", func(t *testing.T) {
+		m := &ReplayBlockRequest{}
+		err := m.Unmarshal(buildPayload(MaxReplayBlockMsgs))
+		require.NoError(t, err)
+		require.Len(t, m.Msgs, MaxReplayBlockMsgs)
+	})
+}


### PR DESCRIPTION
### What

Caps the number of eth message elements the `ReplayBlockRequest` decoder will allocate, in `x/cronos/types/query.pb.go`'s generated `Unmarshal`, sourced from a new `MaxReplayBlockMsgs` constant in `x/cronos/types/query.go`. The keeper's existing count/gas bounds (#2131) now reference the same constant instead of duplicating it.

### Issue

The public native gRPC `ReplayBlock` endpoint takes an uncapped `repeated` list of `MsgEthereumTx`. An empty element encodes to just 2 bytes, so a request just under the 10MiB receive limit can pack over 5 million elements. Decoding that request allocates hundreds of MiB and can OOM-kill the process — and this happens during `ProtoCodec.Unmarshal`, before the keeper handler (and its #2131 length check) ever runs. Two concurrent requests reproduced a fatal Go runtime OOM in testing.

### Solution

- Added `MaxReplayBlockMsgs` in `x/cronos/types/query.go` as the single source of truth.
- Patched the generated `ReplayBlockRequest.Unmarshal` (`query.pb.go`) to reject once the element count exceeds the cap, before appending further elements — bounding decode-time allocation regardless of message-size limits.
- This edits generated code by hand; if `query.pb.go` is regenerated, the check must be re-added (flagged in a comment at both sites).
- `x/cronos/keeper/grpc_query.go` now references `types.MaxReplayBlockMsgs`.

### Test

- New `x/cronos/types/query_test.go`: crafts a raw wire payload with `MaxReplayBlockMsgs+1` empty elements and asserts `Unmarshal` rejects it without appending past the cap; also asserts a payload at exactly the cap still decodes.
- Existing `x/cronos/keeper/grpc_query_test.go` (`TestReplayBlockBounds`) still passes, updated to reference the relocated constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replay block requests now enforce a maximum of 10,000 Ethereum messages during decoding.
  * Excessively large requests are rejected earlier, helping prevent excessive memory usage.
  * Added validation coverage for requests at and beyond the allowed message limit.

* **Documentation**
  * Updated the unreleased changelog with the ReplayBlock message-count limit fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->