### PR TITLE
fix(app): retry block list decryption instead of caching the blob before it is applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 
+* [#2175](https://github.com/crypto-org-chain/cronos/pull/2175) fix(app): retry block list decryption instead of caching the blob before it is applied.
 * [#2155](https://github.com/crypto-org-chain/cronos/pull/2155) fix(mempool): size tx-cache-size and max-tx-bytes from mempool config directly.
 * [#2169](https://github.com/crypto-org-chain/cronos/pull/2169) fix(cronos): add safe multiply int check during voucher conversion to EVM coins.
 * [#2172](https://github.com/crypto-org-chain/cronos/pull/2172) fix(e2ee): cap the address batch in the `Keys` query.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug fixes
 
-* [#2175](https://github.com/crypto-org-chain/cronos/pull/2175) fix(app): retry block list decryption instead of caching the blob before it is applied.
+* [#2176](https://github.com/crypto-org-chain/cronos/pull/2176) fix(app): retry block list decryption instead of caching the blob before it is applied.
 * [#2155](https://github.com/crypto-org-chain/cronos/pull/2155) fix(mempool): size tx-cache-size and max-tx-bytes from mempool config directly.
 * [#2169](https://github.com/crypto-org-chain/cronos/pull/2169) fix(cronos): add safe multiply int check during voucher conversion to EVM coins.
 * [#2172](https://github.com/crypto-org-chain/cronos/pull/2172) fix(e2ee): cap the address batch in the `Keys` query.

--- a/app/proposal.go
+++ b/app/proposal.go
@@ -215,11 +215,10 @@ func (h *ProposalHandler) SetBlockList(blob []byte) error {
 	if bytes.Equal(h.lastBlockList, blob) {
 		return nil
 	}
-	h.lastBlockList = make([]byte, len(blob))
-	copy(h.lastBlockList, blob)
 
 	if len(blob) == 0 {
 		h.blocklist = make(map[string]struct{})
+		h.lastBlockList = nil
 		return nil
 	}
 
@@ -256,6 +255,10 @@ func (h *ProposalHandler) SetBlockList(blob []byte) error {
 	}
 
 	h.blocklist = m
+	// Only record the blob once it has been successfully applied, so a failed
+	// decrypt/parse is retried on the next call instead of getting stuck.
+	h.lastBlockList = make([]byte, len(blob))
+	copy(h.lastBlockList, blob)
 	return nil
 }
 

--- a/app/proposal.go
+++ b/app/proposal.go
@@ -255,8 +255,6 @@ func (h *ProposalHandler) SetBlockList(blob []byte) error {
 	}
 
 	h.blocklist = m
-	// Only record the blob once it has been successfully applied, so a failed
-	// decrypt/parse is retried on the next call instead of getting stuck.
 	h.lastBlockList = make([]byte, len(blob))
 	copy(h.lastBlockList, blob)
 	return nil

--- a/app/proposal_test.go
+++ b/app/proposal_test.go
@@ -1,17 +1,21 @@
 package app
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"math/big"
 	"testing"
 
+	"filippo.io/age"
 	cmttypes "github.com/cometbft/cometbft/types"
 	cronosmempool "github.com/crypto-org-chain/cronos/app/mempool"
 	"github.com/stretchr/testify/require"
 	protov2 "google.golang.org/protobuf/proto"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
 )
 
 const invalidTx = "invalid"
@@ -156,6 +160,43 @@ func TestCacheProposalTxVerifier(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, []byte("raw"), bz)
 	})
+}
+
+func encryptBlockList(t *testing.T, recipient age.Recipient, addrs ...string) []byte {
+	t.Helper()
+	body, err := json.Marshal(BlockList{Addresses: addrs})
+	require.NoError(t, err)
+
+	dst := bytes.NewBuffer(nil)
+	w, err := age.Encrypt(dst, recipient)
+	require.NoError(t, err)
+	_, err = w.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	return dst.Bytes()
+}
+
+func TestSetBlockListRetriesAfterFailure(t *testing.T) {
+	identity, err := age.GenerateX25519Identity()
+	require.NoError(t, err)
+	addressCodec := authcodec.NewBech32Codec("cosmos")
+	h := NewProposalHandler(nil, identity, addressCodec)
+
+	blocked, err := addressCodec.BytesToString(bytes.Repeat([]byte{0x1}, 20))
+	require.NoError(t, err)
+
+	corrupt := []byte("not a valid age ciphertext")
+	require.Error(t, h.SetBlockList(corrupt))
+
+	// Same blob again: must retry the decrypt/parse instead of caching the
+	// prior failure and short-circuiting on the equality check.
+	require.Error(t, h.SetBlockList(corrupt))
+	require.Empty(t, h.blocklist)
+
+	valid := encryptBlockList(t, identity.Recipient(), blocked)
+	require.NoError(t, h.SetBlockList(valid))
+	_, ok := h.blocklist[blocked]
+	require.True(t, ok)
 }
 
 func TestProtoSizeForTx(t *testing.T) {


### PR DESCRIPTION
### What

`ProposalHandler.SetBlockList` recorded the raw blob in `h.lastBlockList` *before* decrypting and parsing it. If decrypt, unmarshal, or bech32 conversion failed, the blob was already cached, so the `bytes.Equal(h.lastBlockList, blob)` fast path in the next `RefreshBlockList` short-circuited — permanently. Since `RefreshBlockList` runs from the EndBlocker every block, one failed parse left blocklist enforcement stuck at its previous state for the life of the process, with no retry and no way to recover short of a restart.

### Solution

- Record `lastBlockList` only after the blob has actually been applied: `nil` on the empty-blob branch, and after `h.blocklist = m` on the success path.
- A failure now leaves `lastBlockList` untouched, so the next block retries the same blob.
- The empty-blob case still short-circuits correctly on repeat, since `bytes.Equal(nil, []byte{})` is true — no per-block rework.

Cost while a bad blob sits on chain: one age decrypt + unmarshal per block. Cheap, and only happens in an already-misconfigured state that an operator must fix.

### Test

`TestSetBlockListRetriesAfterFailure` calls `SetBlockList` twice with the same corrupt blob, asserts both error, then asserts a valid blob succeeds. Verified it fails against the pre-fix logic (second call returned `nil` — silently "succeeding").
