### PR TITLE
fix(cronos): enforce the source-denom contract address match on the genesis token mapping path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### State Machine Breaking
 
+* [#2177](https://github.com/crypto-org-chain/cronos/pull/2177) fix(cronos): enforce the source-denom contract address match on the genesis token mapping path.
 * [#2171](https://github.com/crypto-org-chain/cronos/pull/2171) fix(cronos): reject `MsgTurnBridge` instead of reporting success for a no-op.
 
 ### Bug fixes

--- a/x/cronos/genesis.go
+++ b/x/cronos/genesis.go
@@ -19,12 +19,10 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	}
 
 	for _, m := range genState.ExternalContracts {
-		// Only allow IBC, gravity, or cronos denoms at genesis.
-		if !types.IsValidIBCDenom(m.Denom) && !types.IsValidGravityDenom(m.Denom) && !types.IsValidCronosDenom(m.Denom) {
-			panic(fmt.Sprintf("Invalid denom to map to contract: %s", m.Denom))
-		}
-		if !common.IsHexAddress(m.Contract) {
-			panic(fmt.Sprintf("Invalid contract address: %s", m.Contract))
+		// Only allow IBC, gravity, or cronos denoms at genesis, and for a source
+		// (cronos) denom, require the contract to match the address embedded in it.
+		if err := types.ValidateTokenMapping(m.Denom, m.Contract); err != nil {
+			panic(err)
 		}
 		if err := k.SetExternalContractForDenom(ctx, m.Denom, common.HexToAddress(m.Contract)); err != nil {
 			panic(err)
@@ -32,12 +30,10 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	}
 
 	for _, m := range genState.AutoContracts {
-		// Only allow IBC, gravity, or cronos denoms at genesis.
-		if !types.IsValidIBCDenom(m.Denom) && !types.IsValidGravityDenom(m.Denom) && !types.IsValidCronosDenom(m.Denom) {
-			panic(fmt.Sprintf("Invalid denom to map to contract: %s", m.Denom))
-		}
-		if !common.IsHexAddress(m.Contract) {
-			panic(fmt.Sprintf("Invalid contract address: %s", m.Contract))
+		// Only allow IBC, gravity, or cronos denoms at genesis, and for a source
+		// (cronos) denom, require the contract to match the address embedded in it.
+		if err := types.ValidateTokenMapping(m.Denom, m.Contract); err != nil {
+			panic(err)
 		}
 		if err := k.SetAutoContractForDenom(ctx, m.Denom, common.HexToAddress(m.Contract)); err != nil {
 			if errors.Is(err, types.ErrExternalMappingExists) || errors.Is(err, types.ErrDenomAlreadyMapped) {

--- a/x/cronos/genesis_test.go
+++ b/x/cronos/genesis_test.go
@@ -131,6 +131,34 @@ func (suite *CronosTestSuite) TestInitGenesis() {
 			false,
 		},
 		{
+			"Source denom external mapping mismatched contract panics",
+			func() {},
+			&types.GenesisState{
+				Params: types.DefaultParams(),
+				ExternalContracts: []types.TokenMapping{
+					{
+						Denom:    "cronos0x0000000000000000000000000000000000000005",
+						Contract: "0x0000000000000000000000000000000000000006",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"Source denom auto mapping mismatched contract panics",
+			func() {},
+			&types.GenesisState{
+				Params: types.DefaultParams(),
+				AutoContracts: []types.TokenMapping{
+					{
+						Denom:    "cronos0x0000000000000000000000000000000000000007",
+						Contract: "0x0000000000000000000000000000000000000008",
+					},
+				},
+			},
+			true,
+		},
+		{
 			"Conflicting auto mapping panics",
 			func() {},
 			&types.GenesisState{

--- a/x/cronos/keeper/keeper.go
+++ b/x/cronos/keeper/keeper.go
@@ -200,8 +200,10 @@ func validateContractAddressForSourceDenom(denom string, address common.Address,
 }
 
 // SetExternalContractForDenom sets denom→external CRC21 mapping for an unmapped denom.
-// Caller is responsible for source-denom specific validation before calling this method.
 func (k Keeper) SetExternalContractForDenom(ctx sdk.Context, denom string, address common.Address) error {
+	if err := validateContractAddressForSourceDenom(denom, address, types.IsSourceCoin(denom)); err != nil {
+		return err
+	}
 	if err := k.ensureDenomNotMapped(ctx, denom); err != nil {
 		return err
 	}

--- a/x/cronos/keeper/keeper_test.go
+++ b/x/cronos/keeper/keeper_test.go
@@ -250,7 +250,7 @@ func (suite *KeeperTestSuite) TestDenomContractMap() {
 			},
 		},
 		{
-			"success, SetExternalContractForDenom accepts mismatched contract for source denom",
+			"failure, SetExternalContractForDenom rejects mismatched contract for source denom",
 			func() {
 				keeper := suite.app.CronosKeeper
 
@@ -259,10 +259,9 @@ func (suite *KeeperTestSuite) TestDenomContractMap() {
 				mismatched := common.BigToAddress(big.NewInt(13))
 
 				err := keeper.SetExternalContractForDenom(suite.ctx, sourceDenom, mismatched)
-				suite.Require().NoError(err)
-				contract, found := keeper.GetContractByDenom(suite.ctx, sourceDenom)
-				suite.Require().True(found)
-				suite.Require().Equal(mismatched, contract)
+				suite.Require().Error(err)
+				_, found := keeper.GetContractByDenom(suite.ctx, sourceDenom)
+				suite.Require().False(found)
 			},
 		},
 		{

--- a/x/cronos/types/genesis.go
+++ b/x/cronos/types/genesis.go
@@ -22,5 +22,20 @@ func (gs GenesisState) Validate() error {
 
 	// this line is used by starport scaffolding # genesis/types/validate
 
-	return gs.Params.Validate()
+	if err := gs.Params.Validate(); err != nil {
+		return err
+	}
+
+	for _, m := range gs.ExternalContracts {
+		if err := ValidateTokenMapping(m.Denom, m.Contract); err != nil {
+			return err
+		}
+	}
+	for _, m := range gs.AutoContracts {
+		if err := ValidateTokenMapping(m.Denom, m.Contract); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/x/cronos/types/genesis_test.go
+++ b/x/cronos/types/genesis_test.go
@@ -28,6 +28,71 @@ func TestGenesisStateValidate(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"valid external contract mapping",
+			GenesisState{
+				Params: DefaultParams(),
+				ExternalContracts: []TokenMapping{
+					{
+						Denom:    "ibc/6B5A664BF0AF4F71B2F0BAA33141E2F1321242FBD5D19762F541EC971ACB0865",
+						Contract: "0x0000000000000000000000000000000000000001",
+					},
+				},
+			},
+			false,
+		},
+		{
+			"valid source denom mapping with matching contract",
+			GenesisState{
+				Params: DefaultParams(),
+				AutoContracts: []TokenMapping{
+					{
+						Denom:    "cronos0x0000000000000000000000000000000000000004",
+						Contract: "0x0000000000000000000000000000000000000004",
+					},
+				},
+			},
+			false,
+		},
+		{
+			"invalid denom in external contract mapping",
+			GenesisState{
+				Params: DefaultParams(),
+				ExternalContracts: []TokenMapping{
+					{
+						Denom:    "aaa/6B5A664BF0AF4F71B2F0BAA33141E2F1321242FBD5D19762F541EC971ACB0865",
+						Contract: "0x0000000000000000000000000000000000000001",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"source denom mapping with mismatched contract in external contracts",
+			GenesisState{
+				Params: DefaultParams(),
+				ExternalContracts: []TokenMapping{
+					{
+						Denom:    "cronos0x0000000000000000000000000000000000000005",
+						Contract: "0x0000000000000000000000000000000000000006",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"source denom mapping with mismatched contract in auto contracts",
+			GenesisState{
+				Params: DefaultParams(),
+				AutoContracts: []TokenMapping{
+					{
+						Denom:    "cronos0x0000000000000000000000000000000000000007",
+						Contract: "0x0000000000000000000000000000000000000008",
+					},
+				},
+			},
+			true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/x/cronos/types/types.go
+++ b/x/cronos/types/types.go
@@ -60,3 +60,29 @@ func GetContractAddressFromDenom(denom string) (string, error) {
 	}
 	return contractAddress, nil
 }
+
+// ValidateTokenMapping performs the stateless checks a denom/contract token mapping
+// must satisfy: the denom must be a valid IBC, gravity, or cronos denom; the contract
+// must be a hex address; and for a source (cronos) denom, the contract must equal the
+// address embedded in the denom itself.
+func ValidateTokenMapping(denom, contract string) error {
+	if !IsValidCoinDenom(denom) {
+		return fmt.Errorf("invalid denom to map to contract: %s", denom)
+	}
+	if !common.IsHexAddress(contract) {
+		return fmt.Errorf("invalid contract address: %s", contract)
+	}
+	if IsSourceCoin(denom) {
+		contractFromDenom, err := GetContractAddressFromDenom(denom)
+		if err != nil {
+			return err
+		}
+		if !strings.EqualFold(contractFromDenom, contract) {
+			return fmt.Errorf(
+				"the contract address for source denom %s is %s, mismatch with requested contract %s",
+				denom, common.HexToAddress(contractFromDenom).Hex(), common.HexToAddress(contract).Hex(),
+			)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
### What

A `cronos0x…` source denom must map to the contract named in the denom itself — that invariant is what stops `SendToIbcHandler`'s source-denom branch from minting native coins on an event emitted by an arbitrary contract. `InitGenesis`'s `ExternalContracts` loop never checked it: it validated only the denom shape and `common.IsHexAddress`, then called `SetExternalContractForDenom` directly. A crafted genesis could therefore map `cronos0xAAA…` to an unrelated attacker contract, and every `__CronosSendToIbc` event from that contract would mint unbacked `cronos0xAAA…`.

### Issue

The gap came from an asymmetry introduced in #2029. `SetAutoContractForDenom` enforces the match internally; `SetExternalContractForDenom` was left permissive with a "caller is responsible for source-denom specific validation" comment, because its only production caller at the time (`RegisterOrUpdateTokenMapping`) already validated. `InitGenesis` was the second, unnoticed caller. An existing test case asserted the permissive behavior — this PR flips it, since it encoded the assumption rather than a deliberate allowance.

### Solution

- `SetExternalContractForDenom` now calls `validateContractAddressForSourceDenom` itself, making it symmetric with `SetAutoContractForDenom`. Stale doc comment removed.
- New exported `types.ValidateTokenMapping(denom, contract)` used by both `InitGenesis` loops, replacing the inline shape checks (equivalent: `IsValidCoinDenom` is exactly the old IBC/gravity/cronos triple).
- `GenesisState.Validate()` now iterates `ExternalContracts` and `AutoContracts` so `validate-genesis` catches it too.
- The non-source branch of `RegisterOrUpdateTokenMapping` is unaffected — `IsSourceCoin` is false there, so the new check is a no-op.

Deliberately **not** added: an `ensureContractCode`-style check at genesis, which would need EVM state during `InitGenesis` and a separate mainnet audit.

### Rollout risk

Marked State Machine Breaking. `GenesisState.Validate()` runs from `validate-genesis`, not from `InitChain` — chain-start enforcement comes from the `InitGenesis` loops. Since #2029 every live mutation path already enforced the match, so a chain that only ever went through `RegisterOrUpdateTokenMapping` exports cleanly. But any pre-#2029 mismatched mapping still in state will now **panic on a fresh `InitGenesis`** (regenesis, disaster recovery, genesis-file sync) and fail `validate-genesis`. Operators should audit current `ExternalContracts`/`AutoContracts` against `ValidateTokenMapping` before relying on regenesis from an export.

### Test

Table-driven cases for accept and reject in `x/cronos/types/genesis_test.go`, `x/cronos/genesis_test.go`, and `x/cronos/keeper/keeper_test.go`; the reject cases are a direct inversion of the previously-accepted state, so they fail without the change. `go test -tags objstore ./x/cronos/...` passes; full build clean.
